### PR TITLE
Add missing method to ActionUtils

### DIFF
--- a/src/main/java/org/oscarehr/integration/mcedt/mailbox/ActionUtils.java
+++ b/src/main/java/org/oscarehr/integration/mcedt/mailbox/ActionUtils.java
@@ -361,6 +361,12 @@ public class ActionUtils {
         }
     }
 
+    public static void createOnEDTOutboxDir() {
+        OscarProperties props = OscarProperties.getInstance();
+        File dateDir = new File(props.getProperty("ONEDT_OUTBOX", ""));
+        if (!dateDir.exists()) dateDir.mkdirs();
+    }
+
     public static Date getOutboxTimestamp() {
         Date startDate = new Date();
         try {

--- a/src/main/java/oscar/oscarReport/data/ObecData.java
+++ b/src/main/java/oscar/oscarReport/data/ObecData.java
@@ -104,28 +104,28 @@ public class ObecData {
         return outputString;
     }
 
-	public String writeFile(String value1, Properties pp) {
-		String obecFilename = "";
-		try {
-			String oscarHome = pp.getProperty("DOCUMENT_DIR");
+    public String writeFile(String value1, Properties pp) {
+        String obecFilename = "";
+        try {
+            String oscarHome = pp.getProperty("DOCUMENT_DIR");
 
-			String outbox = pp.getProperty("ONEDT_OUTBOX", "");
-			Path outboxPath = Paths.get(outbox);
-			File outboxFile = outboxPath.toFile();
+            String outbox = pp.getProperty("ONEDT_OUTBOX", "");
+            Path outboxPath = Paths.get(outbox);
+            File outboxFile = outboxPath.toFile();
 
-			// Construct the filename
-			obecFilename = "OBECE" + System.currentTimeMillis() + ".TXT";
-			File srcFile = Paths.get(oscarHome, obecFilename).toFile();
+            // Construct the filename
+            obecFilename = "OBECE" + System.currentTimeMillis() + ".TXT";
+            File srcFile = Paths.get(oscarHome, obecFilename).toFile();
 
-			// Write the content to the file
-			Files.write(srcFile.toPath(), value1.getBytes(), StandardOpenOption.CREATE);
+            // Write the content to the file
+            Files.write(srcFile.toPath(), value1.getBytes(), StandardOpenOption.CREATE);
 
-			// Copy the file to the EDT outbox directory
-			if (!outboxFile.exists()) { ActionUtils.createOnEDTOutboxDir(); }
-			ActionUtils.copyFileToDirectory(srcFile, outboxFile, false, true);
-		} catch (Exception e) {
-			logger.error("Error writing or copying file", e);
-		}
-		return obecFilename;
-	}
+            // Copy the file to the EDT outbox directory
+            if (!outboxFile.exists()) { ActionUtils.createOnEDTOutboxDir(); }
+            ActionUtils.copyFileToDirectory(srcFile, outboxFile, false, true);
+        } catch (Exception e) {
+            logger.error("Error writing or copying file", e);
+        }
+        return obecFilename;
+    }
 };


### PR DESCRIPTION
## Changes made
- Add missing createOnEDTOutboxDir method to ActionUtils.java.
- Reformat tabs to spaces in ObecData.java.

## Summary by Sourcery

Add a missing method to ActionUtils.java to handle the creation of the EDT outbox directory and reformat code in ObecData.java for consistency.

New Features:
- Add the createOnEDTOutboxDir method to ActionUtils.java to ensure the creation of the EDT outbox directory if it does not exist.

Enhancements:
- Reformat tabs to spaces in ObecData.java for consistent code formatting.