### PR TITLE
Pom security updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
-            <version>3.3.1</version>
+            <version>3.7.1</version>
         </dependency>
 
         <!-- struts -->

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->

--- a/pom.xml
+++ b/pom.xml
@@ -365,13 +365,6 @@
             <version>3.3.1</version>
         </dependency>
 
-        <!-- google collections lib -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>15.0-rc1</version>
-        </dependency>
-
         <!-- struts -->
         <!-- Struts Core Library -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.24.1</log4j2.version>
         <slf4j.version>1.7.32</slf4j.version>
         <hapifhir.version>5.4.0</hapifhir.version>
         <struts.version>1.3.11</struts.version>

--- a/pom.xml
+++ b/pom.xml
@@ -546,17 +546,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
+            <version>2.12.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.12.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.9</version>
+            <version>2.12.7</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.barbecue</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1240,7 +1240,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.5</version>
+            <version>1.28.5</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1329,7 +1329,7 @@
         <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>
-            <version>1.8</version>
+            <version>1.9.3</version>
         </dependency>
 
 <!-- Selenium test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -1708,7 +1708,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.20</version>
+                <version>11.0.24</version>
             </plugin>
             <!--
             Comming soon. After spring and java upgrades


### PR DESCRIPTION
Cumulative security updates and POM cleanup.

Updates introduce no breaking changes while eliminating exposure to critical CVEs.

## Summary by Sourcery

Perform security updates and cleanup in the POM file by upgrading various dependencies to eliminate exposure to critical CVEs without introducing breaking changes.

Enhancements:
- Update Log4j2 to version 2.24.1 to address security vulnerabilities.
- Upgrade commons-fileupload to version 1.5 for improved security.
- Update imageio-jpeg to version 3.7.1 for better performance and security.
- Upgrade Jackson core, databind, and annotations to version 2.12.7 and 2.12.7.2 to fix security issues.
- Update Apache Tika to version 1.28.5 to address known vulnerabilities.
- Upgrade Jasypt to version 1.9.3 for enhanced security.
- Update Jetty Maven Plugin to version 11.0.24 for improved stability and security.