### PR TITLE
Pom security updates alpaca

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,71 @@
 			<classifier>jdk15</classifier>
 		</dependency>
 
+        <!-- jasper reports -->
+        <dependency>
+            <groupId>net.sf.jasperreports</groupId>
+            <artifactId>jasperreports</artifactId>
+            <version>6.17.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>bouncycastle</groupId>
+                    <artifactId>bcprov-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>bouncycastle</groupId>
+                    <artifactId>bcmail-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bctsp-jdk14</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.lowagie</groupId>
+                    <artifactId>itext</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>jasperreports</groupId>
+            <artifactId>htmlcomponent</artifactId>
+            <version>6.8.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.7.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.12.7</version>
+        </dependency>
+
 		<!-- apache xmlrpc -->
 		<dependency>
 			<groupId>xmlrpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -363,22 +363,22 @@
   			<version>lgpl</version>
 		</dependency>
 
-		<!--  pdfbox -->
-		 <dependency>
-	      <groupId>org.apache.pdfbox</groupId>
-	      <artifactId>pdfbox</artifactId>
-			<version>2.0.27</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.pdfbox</groupId>
-			<artifactId>jbig2-imageio</artifactId>
-			<version>3.0.4</version>
-		</dependency>
-		<dependency>
-			<groupId>com.twelvemonkeys.imageio</groupId>
-			<artifactId>imageio-jpeg</artifactId>
-			<version>3.3.1</version>
-	    </dependency>
+        <!--  pdfbox -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.27</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>jbig2-imageio</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-jpeg</artifactId>
+            <version>3.7.1</version>
+        </dependency>
 
 		<!-- struts -->
 <!--		<dependency>-->

--- a/pom.xml
+++ b/pom.xml
@@ -380,13 +380,6 @@
 			<version>3.3.1</version>
 	    </dependency>
 
-		<!-- google collections lib -->
-	    <dependency>
-    		<groupId>com.google.guava</groupId>
-    		<artifactId>guava</artifactId>
-    		<version>15.0-rc1</version>
-	    </dependency>
-
 		<!-- struts -->
 <!--		<dependency>-->
 <!--			<groupId>struts</groupId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -1371,31 +1371,30 @@
 		<version>20171101</version>
 	</dependency>
 
+    <dependency>
+        <groupId>com.medseek</groupId>
+        <artifactId>PatientService</artifactId>
+        <version>20161213</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jasypt</groupId>
+        <artifactId>jasypt</artifactId>
+        <version>1.9.3</version>
+    </dependency>
+
+	<!-- https://mvnrepository.com/artifact/org.xhtmlrenderer/flying-saucer-core -->
 	<dependency>
-		<groupId>com.medseek</groupId>
-		<artifactId>PatientService</artifactId>
-		<version>20161213</version>
+		<groupId>org.xhtmlrenderer</groupId>
+		<artifactId>flying-saucer-core</artifactId>
+		<version>9.4.1</version>
 	</dependency>
+
+	<!-- https://mvnrepository.com/artifact/org.xhtmlrenderer/flying-saucer-pdf -->
 	<dependency>
-	    <groupId>org.jasypt</groupId>
-	    <artifactId>jasypt</artifactId>
-	    <version>1.8</version>
+		<groupId>org.xhtmlrenderer</groupId>
+		<artifactId>flying-saucer-pdf</artifactId>
+		<version>9.4.1</version>
 	</dependency>
-
-
-		<!-- https://mvnrepository.com/artifact/org.xhtmlrenderer/flying-saucer-core -->
-		<dependency>
-			<groupId>org.xhtmlrenderer</groupId>
-			<artifactId>flying-saucer-core</artifactId>
-			<version>9.4.1</version>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/org.xhtmlrenderer/flying-saucer-pdf -->
-		<dependency>
-			<groupId>org.xhtmlrenderer</groupId>
-			<artifactId>flying-saucer-pdf</artifactId>
-			<version>9.4.1</version>
-		</dependency>
 
 		<!-- Caisi Integrator -->
 	<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -184,11 +184,11 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.13.0</version>
 		</dependency>
-		<dependency>
-				<groupId>commons-fileupload</groupId>
-				<artifactId>commons-fileupload</artifactId>
-				<version>1.4</version>
-		</dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.5</version>
+        </dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1879,6 +1879,31 @@ Comming soon. After spring and java upgrades
 			<!--			<exclude>src/main/webapp/report/reportonbilledvisitprovider.jsp</exclude>-->
 			<!--			<exclude>src/main/webapp/report/reportonedblist.jsp</exclude>-->
 			<!--			<exclude>src/main/webapp/report/reportResult.jsp</exclude>-->
+            <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-maven-plugin -->
+            
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>11.0.24</version>
+            </plugin>
+
+            <!--Comming soon. After spring and java upgrades
+            <plugin>
+                <groupId>org.apache.axis2</groupId>
+                <artifactId>axis2-wsdl2code-maven-plugin</artifactId>
+                <version>1.5.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>wsdl2code</goal>
+                        </goals>
+                        <configuration>
+                            <packageName>test</packageName>
+                            <wsdlFile>src/main/resources/olis.wsdl</wsdlFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin> -->
 
 			<!--			<exclude>src/main/webapp/billing/billingBrazil.jsp</exclude>-->
 			<!--			<exclude>src/main/webapp/billing/billingBrazilSuccess.jsp</exclude>-->

--- a/pom.xml
+++ b/pom.xml
@@ -1497,195 +1497,197 @@
 			</executions>
 		</plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
-        <configuration>
-	        <propertiesEncoding>ISO-8859-1</propertiesEncoding>
-          <nonFilteredFileExtensions>
-            <nonFilteredFileExtension>pdf</nonFilteredFileExtension>
-            <nonFilteredFileExtension>jar</nonFilteredFileExtension>
-            <nonFilteredFileExtension>xls</nonFilteredFileExtension>
-            <nonFilteredFileExtension>dat</nonFilteredFileExtension>
-            <nonFilteredFileExtension>xsd</nonFilteredFileExtension>
-            <nonFilteredFileExtension>jasper</nonFilteredFileExtension>
-            <nonFilteredFileExtension>doc</nonFilteredFileExtension>
-          </nonFilteredFileExtensions>
-        </configuration>
-      </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>3.3.1</version>
+            <configuration>
+                <propertiesEncoding>ISO-8859-1</propertiesEncoding>
+            <nonFilteredFileExtensions>
+                <nonFilteredFileExtension>pdf</nonFilteredFileExtension>
+                <nonFilteredFileExtension>jar</nonFilteredFileExtension>
+                <nonFilteredFileExtension>xls</nonFilteredFileExtension>
+                <nonFilteredFileExtension>dat</nonFilteredFileExtension>
+                <nonFilteredFileExtension>xsd</nonFilteredFileExtension>
+                <nonFilteredFileExtension>jasper</nonFilteredFileExtension>
+                <nonFilteredFileExtension>doc</nonFilteredFileExtension>
+            </nonFilteredFileExtensions>
+            </configuration>
+        </plugin>
 
-		 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>3.2.0</version>
-                      <executions>
-                        <execution>
-                          <phase>validate</phase>
-                            <goals>
-                              <goal>create</goal>
-                            </goals>
-                        </execution>
-                     </executions>
-                 </plugin>
-	<plugin>
-       		<groupId>org.apache.maven.plugins</groupId>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>buildnumber-maven-plugin</artifactId>
+            <version>3.2.0</version>
+                <executions>
+                <execution>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>create</goal>
+                    </goals>
+                </execution>
+                </executions>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>4.0.0-M13</version>
                 <dependencies>
-					<dependency>
-							<groupId>org.apache.maven.doxia</groupId>
-							<artifactId>doxia-module-markdown</artifactId>
-							<version>2.0.0-M9</version>
-					</dependency>
-				</dependencies>
-				<configuration>
-						<inputEncoding>UTF-8</inputEncoding>
-						<outputEncoding>UTF-8</outputEncoding>
-				</configuration>
+                    <dependency>
+                            <groupId>org.apache.maven.doxia</groupId>
+                            <artifactId>doxia-module-markdown</artifactId>
+                            <version>2.0.0-M9</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                        <inputEncoding>UTF-8</inputEncoding>
+                        <outputEncoding>UTF-8</outputEncoding>
+                </configuration>
         </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>3.1.0</version>
-				<executions>
-					<execution>
-						<phase>process-classes</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<tstamp>
-									<format property="build.dateTime.value" pattern="yyyy-MM-dd hh:mm aa" />
-								</tstamp>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+        </plugin>
 
-								<echo message="build time : ${build.dateTime.value}" />
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+                <execution>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                    <configuration>
+                        <target>
+                            <tstamp>
+                                <format property="build.dateTime.value" pattern="yyyy-MM-dd hh:mm aa" />
+                            </tstamp>
 
-								<replace file="target/classes/oscar_mcmaster.properties" token="${build.dateTime}" value="${build.dateTime.value}" />
+                            <echo message="build time : ${build.dateTime.value}" />
 
-								<property environment="env" />
-								<echo message="JOB_NAME - BUILD_NUMBER : ${env.JOB_NAME}-${env.BUILD_NUMBER}" />
-								<replace file="target/classes/oscar_mcmaster.properties" token="${build.JOB_NAME}" value="${env.JOB_NAME}" />
-								<replace file="target/classes/oscar_mcmaster.properties" token="${build.BUILD_NUMBER}" value="${env.BUILD_NUMBER}" />
-							</target>
-						</configuration>
-					</execution>
+                            <replace file="target/classes/oscar_mcmaster.properties" token="${build.dateTime}" value="${build.dateTime.value}" />
 
-					<execution>
-						<!-- We're doing jspc this way because the codehaus jspc seems to be abandonded,
-						it doesn't go beyond jdk 1.5 and the documentation is sparse, and the source
-						code links to a broken page and I can't find the goals it supports. -->
-						<id>jspc</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<property name="build.compiler" value="extJavac" />
-								<property name='jspc_target' value="${project.artifactId}-${project.version}" />
-								<ant antfile="jspc.xml" target="jspc" />
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+                            <property environment="env" />
+                            <echo message="JOB_NAME - BUILD_NUMBER : ${env.JOB_NAME}-${env.BUILD_NUMBER}" />
+                            <replace file="target/classes/oscar_mcmaster.properties" token="${build.JOB_NAME}" value="${env.JOB_NAME}" />
+                            <replace file="target/classes/oscar_mcmaster.properties" token="${build.BUILD_NUMBER}" value="${env.BUILD_NUMBER}" />
+                        </target>
+                    </configuration>
+                </execution>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.1.2</version>
-				<configuration>
-					<configLocation>utils/checkstyle.xml</configLocation>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<failsOnError>true</failsOnError>
-					<consoleOutput>true</consoleOutput>
-					<linkXRef>false</linkXRef>
-					<includes>src/main/**/*,database/**/*.sql</includes>
-					<excludes>**/*.jar, **/*.txt, **/*.rpt, **/*.fla, **/*.xml, **/*.dtd, **/*.xslt, **/*.doc, **/*.bak, **/*.tld, **/*.jpg, **/*.png, **/*.gif, **/*.pdf, **/*.swf, **/*.js, **/*.css, src/main/webapp/share/calendar/**, **/*svg.jsp, src/main/webapp/casemgmt/Index2.jsp, database/mysql/updates/update-2016-06-06.sql, src/main/java/oscar/oscarMessenger/util/MsgDemoMap.java, src/main/java/oscar/oscarEncounter/pageUtil/EctDisplayMsgAction.java, database/mysql/oscarinit.sql, src/main/webapp/oscarEncounter/Index.jsp, database/mysql/oscarinit_on.sql, database/mysql/oscardata.sql, database/mysql/oscarinit_bc.sql, src/main/java/oscar/oscarEncounter/data/EctPatientData.java</excludes>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<version>9.2.1</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>process-sources</id>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>checkstyle</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+                <execution>
+                    <!-- We're doing jspc this way because the codehaus jspc seems to be abandonded,
+                    it doesn't go beyond jdk 1.5 and the documentation is sparse, and the source
+                    code links to a broken page and I can't find the goals it supports. -->
+                    <id>jspc</id>
+                    <phase>verify</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                    <configuration>
+                        <target>
+                            <property name="build.compiler" value="extJavac" />
+                            <property name='jspc_target' value="${project.artifactId}-${project.version}" />
+                            <ant antfile="jspc.xml" target="jspc" />
+                        </target>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.21.2</version>
-				<!--
-				DO NOT execute until these tests actually pass
-				<executions>
-					<execution>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>pmd</goal>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-				 -->
-				<configuration>
-					<targetJdk>1.8</targetJdk>
-					<rulesets>
-						<ruleset>utils/pmd_rules.xml</ruleset>
-					</rulesets>
-				</configuration>
-			</plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>3.1.2</version>
+            <configuration>
+                <configLocation>utils/checkstyle.xml</configLocation>
+                <encoding>${project.build.sourceEncoding}</encoding>
+                <failsOnError>true</failsOnError>
+                <consoleOutput>true</consoleOutput>
+                <linkXRef>false</linkXRef>
+                <includes>src/main/**/*,database/**/*.sql</includes>
+                <excludes>**/*.jar, **/*.txt, **/*.rpt, **/*.fla, **/*.xml, **/*.dtd, **/*.xslt, **/*.doc, **/*.bak, **/*.tld, **/*.jpg, **/*.png, **/*.gif, **/*.pdf, **/*.swf, **/*.js, **/*.css, src/main/webapp/share/calendar/**, **/*svg.jsp, src/main/webapp/casemgmt/Index2.jsp, database/mysql/updates/update-2016-06-06.sql, src/main/java/oscar/oscarMessenger/util/MsgDemoMap.java, src/main/java/oscar/oscarEncounter/pageUtil/EctDisplayMsgAction.java, database/mysql/oscarinit.sql, src/main/webapp/oscarEncounter/Index.jsp, database/mysql/oscarinit_on.sql, database/mysql/oscardata.sql, database/mysql/oscarinit_bc.sql, src/main/java/oscar/oscarEncounter/data/EctPatientData.java</excludes>
+            </configuration>
+            <dependencies>
+                <dependency>
+                    <groupId>com.puppycrawl.tools</groupId>
+                    <artifactId>checkstyle</artifactId>
+                    <version>9.2.1</version>
+                </dependency>
+            </dependencies>
+            <executions>
+                <execution>
+                    <id>process-sources</id>
+                    <phase>process-sources</phase>
+                    <goals>
+                        <goal>checkstyle</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
 
-		     <plugin>
-		        <groupId>org.apache.maven.plugins</groupId>
-		        <artifactId>maven-surefire-plugin</artifactId>
-			     <version>3.2.5</version>
-		        <configuration>
-		          <skipTests>false</skipTests>
-						<!--Required to comment out the following line to run Jacoco reporting-->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <version>3.21.2</version>
+            <!--
+            DO NOT execute until these tests actually pass
+            <executions>
+                <execution>
+                    <phase>process-sources</phase>
+                    <goals>
+                        <goal>pmd</goal>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+                -->
+            <configuration>
+                <targetJdk>1.8</targetJdk>
+                <rulesets>
+                    <ruleset>utils/pmd_rules.xml</ruleset>
+                </rulesets>
+            </configuration>
+        </plugin>
+
+        <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.2.5</version>
+        <configuration>
+            <skipTests>false</skipTests>
+                <!--Required to comment out the following line to run Jacoco reporting-->
 <!--		          <argLine>${surefireArgLine} -Xms4096m -Xmx4096m -Xss2048k -XX:MaxNewSize=256m -XX:MaxPermSize=512m</argLine>-->
-					<excludes>
-						<exclude>**/*EDTTest.java</exclude>
-						<exclude>**/HinValidatorTest.java</exclude>
-						<exclude>**/AR2005*.java</exclude>
-						<exclude>**/OntarioMDSpec4DataTest.java</exclude>
-						<exclude>**/ONAREnhancedBornConnectorTest.java</exclude>
-						<exclude>org/oscarehr/e2e/**/*.java</exclude>
-					</excludes>
-				  <systemPropertyVariables>
-						 <oscar.dbinit.skip>${oscar.dbinit.skip}</oscar.dbinit.skip>
-						 <buildDirectory>${project.build.directory}</buildDirectory>
-				  </systemPropertyVariables>
-		        </configuration>
+            <excludes>
+                <exclude>**/*EDTTest.java</exclude>
+                <exclude>**/HinValidatorTest.java</exclude>
+                <exclude>**/AR2005*.java</exclude>
+                <exclude>**/OntarioMDSpec4DataTest.java</exclude>
+                <exclude>**/ONAREnhancedBornConnectorTest.java</exclude>
+                <exclude>org/oscarehr/e2e/**/*.java</exclude>
+            </excludes>
+            <systemPropertyVariables>
+                    <oscar.dbinit.skip>${oscar.dbinit.skip}</oscar.dbinit.skip>
+                    <buildDirectory>${project.build.directory}</buildDirectory>
+            </systemPropertyVariables>
+        </configuration>
 
-		      </plugin>
+        </plugin>
 
 		<!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-maven-plugin -->
 		<plugin>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-maven-plugin</artifactId>
-			<version>11.0.20</version>
+			<version>11.0.24</version>
 		</plugin>
 <!--
 Comming soon. After spring and java upgrades
@@ -1727,55 +1729,55 @@ Comming soon. After spring and java upgrades
 		</configuration>
 	</plugin>
 -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-						<id>timestamp-property</id>
-						<goals>
-							<goal>timestamp-property</goal>
-						</goals>
-						<configuration>
-							<name>build.time</name>
-							<pattern>yy.MM.dd-HHmmss</pattern>
-							<locale>en_US</locale>
-							<timeZone>Canada/Eastern</timeZone>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+                <execution>
+                    <id>timestamp-property</id>
+                    <goals>
+                        <goal>timestamp-property</goal>
+                    </goals>
+                    <configuration>
+                        <name>build.time</name>
+                        <pattern>yy.MM.dd-HHmmss</pattern>
+                        <locale>en_US</locale>
+                        <timeZone>Canada/Eastern</timeZone>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
 
-			<!-- Update lockfile - mvn se.vandmo:dependency-lock-maven-plugin:lock -->
-			<plugin>
-            	<groupId>se.vandmo</groupId>
-            	<artifactId>dependency-lock-maven-plugin</artifactId>
-            	<version>1.1.0</version>
-				<executions>
-					<execution>
-						<id>check</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-        	</plugin>
+        <!-- Update lockfile - mvn se.vandmo:dependency-lock-maven-plugin:lock -->
+        <plugin>
+            <groupId>se.vandmo</groupId>
+            <artifactId>dependency-lock-maven-plugin</artifactId>
+            <version>1.1.0</version>
+            <executions>
+                <execution>
+                    <id>check</id>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
 
-			<plugin>
-			<groupId>org.owasp</groupId>
-			<artifactId>dependency-check-maven</artifactId>
-			<version>9.2.0</version> <!-- Use the latest version -->
-			<executions>
-				<execution>
-					<goals>
-						<goal>check</goal>
-					</goals>
-				</execution>
-			</executions>
-		</plugin>
-		</plugins>
+        <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <version>9.2.0</version> <!-- Use the latest version -->
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
 
 			<!--     Maybe one day when the header licences are used again.
 			<plugin>-->
@@ -1878,12 +1880,6 @@ Comming soon. After spring and java upgrades
 			<!--			<exclude>src/main/webapp/report/reportonedblist.jsp</exclude>-->
 			<!--			<exclude>src/main/webapp/report/reportResult.jsp</exclude>-->
             <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-maven-plugin -->
-            
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.24</version>
-            </plugin>
 
             <!--Comming soon. After spring and java upgrades
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -593,6 +593,12 @@
             <version>2.12.7</version>
         </dependency>
 
+    	<dependency>
+			<groupId>net.sourceforge.barbecue</groupId>
+			<artifactId>barbecue</artifactId>
+			<version>1.0.6b</version>
+		</dependency>
+
 		<!-- apache xmlrpc -->
 		<dependency>
 			<groupId>xmlrpc</groupId>
@@ -605,72 +611,6 @@
 			<groupId>drools</groupId>
 			<artifactId>drools-all</artifactId>
 			<version>2.0</version>
-		</dependency>
-
-		<!-- jasper reports -->
-		<dependency>
-			<groupId>net.sf.jasperreports</groupId>
-			<artifactId>jasperreports</artifactId>
-			<version>6.17.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>bouncycastle</groupId>
-					<artifactId>bcprov-jdk14</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>bouncycastle</groupId>
-					<artifactId>bcmail-jdk14</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bcprov-jdk14</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.bouncycastle</groupId>
-					<artifactId>bctsp-jdk14</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.lowagie</groupId>
-					<artifactId>itext</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>jasperreports</groupId>
-			<artifactId>htmlcomponent</artifactId>
-			<version>6.8.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.9.9</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
-			<version>2.9.9</version>
-		</dependency>
-		<dependency>
-			<groupId>net.sourceforge.barbecue</groupId>
-			<artifactId>barbecue</artifactId>
-			<version>1.0.6b</version>
 		</dependency>
 
 		<!-- caisi integrator -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,49 +1,34 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.oscarehr</groupId>
-	<artifactId>oscar</artifactId>
-	<packaging>war</packaging>
-	<version>0-SNAPSHOT</version>
-	<name>OpenO</name>
-	<description>OSCAR McMaster is a web-based electronic medical record (EMR) system initially developed for academic primary care clinics. It has grown into a comprehensive EMR and billing system used by many doctor's offices and private medical clinics in Canada and other parts of the world. The name is derived from where it was created and an acronym; OSCAR stands for Open Source Clinical Application and Resource and McMaster refers to McMaster University, where it was developed. It enables the delivery of evidence resources at the point of care.</description>
-	<issueManagement>
-		<system>SourceForge Tracker</system>
-		<url>https://sourceforge.net/tracker/?group_id=66701</url>
-	</issueManagement>
-	<ciManagement>
-		<system>Jenkins</system>
-		<url>https://jenkins.openosp.ca</url>
-	</ciManagement>
-	<inceptionYear>2001</inceptionYear>
-	<mailingLists>
-		<mailingList>
-			<name>oscarmcmaster-devel</name>
-			<subscribe>https://lists.sourceforge.net/lists/listinfo/oscarmcmaster-devel</subscribe>
-			<post>oscarmcmaster-devel@lists.sourceforge.net</post>
-			<archive>https://sourceforge.net/mailarchive/forum.php?forum_name=oscarmcmaster-devel</archive>
-		</mailingList>
-	</mailingLists>
-	<licenses>
-		<license>
-			<name>GPLv2</name>
-			<url>https://www.gnu.org/licenses/gpl-2.0.txt</url>
-		</license>
-	</licenses>
-	<url>https://www.oscarcanada.org</url>
-	<scm>
-		<url>https://bitbucket.org/openoscar/oscar/wiki/Home</url>
-		<connection>scm:git:https://bitbucket.org/openoscar/oscar/branch/master</connection>
-		<developerConnection>scm:git:ssh:git@bitbucket.org:openoscar/oscar.git</developerConnection>
-		<tag>master</tag>
-	</scm>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<log4j2.version>2.17.0</log4j2.version>
-		<slf4j.version>1.7.32</slf4j.version>
-		<hapifhir.version>5.4.0</hapifhir.version>
-		<struts.version>1.3.11</struts.version>
-	</properties>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.oscarehr</groupId>
+    <artifactId>oscar</artifactId>
+    <packaging>war</packaging>
+    <version>0-SNAPSHOT</version>
+    <name>OpenO</name>
+    <description>OpenOSP EMR is a web-based electronic medical record (EMR) system.</description>
+    <inceptionYear>2018</inceptionYear>
+    <licenses>
+        <license>
+            <name>GPLv2</name>
+            <url>https://www.gnu.org/licenses/gpl-2.0.txt</url>
+        </license>
+    </licenses>
+    <url>https://www.openosp.ca</url>
+    <scm>
+        <url>https://bitbucket.org/openoscar/oscar/wiki/Home</url>
+        <connection>scm:git:https://bitbucket.org/openoscar/oscar/branch/master</connection>
+        <developerConnection>scm:git:ssh:git@bitbucket.org:openoscar/oscar.git</developerConnection>
+        <tag>master</tag>
+    </scm>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <log4j2.version>2.24.1</log4j2.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <hapifhir.version>5.4.0</hapifhir.version>
+        <struts.version>1.3.11</struts.version>
+    </properties>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
Add security updates introduced to bullfrog in PR #9 to alpaca.

## Summary by Sourcery

Implement security updates in the pom.xml file by upgrading various dependencies and plugins to newer versions, enhancing the project's security and functionality.

Enhancements:
- Update log4j2 version to 2.24.1 for improved security.
- Upgrade commons-fileupload dependency to version 1.5.
- Update imageio-jpeg dependency to version 3.7.1.
- Add new dependencies for jasperreports, jackson-core, jackson-databind, and jackson-annotations with updated versions.
- Include new plugins for maven-antrun-plugin and maven-checkstyle-plugin with specific configurations.