### PR TITLE
Fix issue with primary key generation in EReferAttachment entity class after Hibernate upgrade

### DIFF
--- a/src/main/java/org/oscarehr/common/model/EReferAttachment.java
+++ b/src/main/java/org/oscarehr/common/model/EReferAttachment.java
@@ -4,6 +4,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
@@ -15,7 +16,7 @@ import java.util.List;
 @Table(name = "erefer_attachment")
 public class EReferAttachment extends AbstractModel<Integer> {
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
 	private Integer id;
 


### PR DESCRIPTION
This PR addresses an issue encountered after upgrading from Hibernate 3 to Hibernate 5. Specifically, when trying to persist entities in the `erefer_attachment` and `erefer_attachment_data` tables, a `java.sql.SQLSyntaxErrorException: Table 'oscar.hibernate_sequence' doesn't exist error occurred.`

### Solution
To fix the issue, I explicitly set the GenerationType.IDENTITY for the EReferAttachment entity class:
```java
@Id
@GeneratedValue(strategy = GenerationType.IDENTITY)
@Column(name = "id")
private Integer id;
``` 
This ensures that the database's native AUTO_INCREMENT feature is used for primary key generation, which is compatible with the current database setup and avoids the need for a sequence generator.

### Why the `erefer_attachment` Table Caused the Issue
The root cause of the issue was related to how Hibernate was generating the primary key values. The way Hibernate interprets the AUTO generation type has changed starting with Hibernate version 5.0.

- **Before Hibernate 5.0:** When `GenerationType.AUTO` was used, Hibernate would typically use the database’s native method for generating primary keys. In the case of MySQL, this would have been the `AUTO_INCREMENT` feature.

- **Starting with Hibernate 5.0:** Hibernate changed the behavior of `GenerationType.AUTO`. Instead of relying on the database's auto-increment feature, Hibernate started using `SequenceStyleGenerator`, even for databases like MySQL, which do not natively support sequences. This required the `hibernate_sequence` table to exist, leading to the error when it was missing.

The issue with the `erefer_attachment` table arose because, after upgrading to Hibernate 5, the default `GenerationType.AUTO` strategy now uses `SequenceStyleGenerato`r, which expects a `hibernate_sequence` table. 
Since the `erefer_attachment` table was empty at the time of the upgrade, Hibernate attempted to use sequences, causing the error due to the missing `hibernate_sequence` table. 

Other entities with existing data didn't encounter this issue because Hibernate had already populated their primary keys, so it didn't need to generate new ones. These entities likely continued using the previous auto-increment mechanism.