### PR TITLE
Java11 upg

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.56-jdk8-openjdk
+FROM tomcat:9.0.56-jdk11
 
 # Labels
 LABEL author="OpenOSP" \

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.56-jdk11
+FROM tomcat:9.0.97-jdk11
 
 # Labels
 LABEL author="OpenOSP" \
@@ -15,9 +15,9 @@ WORKDIR /workspace
 # Install required packages and clean up apt lists
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dos2unix curl git wget apt-transport-https ca-certificates gnupg lsb-release \
-    locales iputils-ping gettext fontconfig libc6 libfreetype6 libjpeg62-turbo \
-    libpng16-16 libssl1.1 libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 \
-    libxrender1 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
+    locales iputils-ping gettext fontconfig libc6 libfreetype6 libjpeg-turbo8 \
+    libpng16-16 libssl3 libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 \
+    libxrender1 libxi6 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
     nano openssh-client vim-tiny \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -1,4 +1,11 @@
-FROM tomcat:9.0.97-jdk11
+FROM openjdk:11-jdk-slim
+
+# Set environment variables for Tomcat
+ENV CATALINA_HOME /usr/local/tomcat
+ENV PATH $CATALINA_HOME/bin:$PATH
+
+# Copy Tomcat installation from the official Tomcat image
+COPY --from=tomcat:9.0.97 /usr/local/tomcat $CATALINA_HOME
 
 # Labels
 LABEL author="OpenOSP" \
@@ -15,8 +22,8 @@ WORKDIR /workspace
 # Install required packages and clean up apt lists
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dos2unix curl git wget apt-transport-https ca-certificates gnupg lsb-release \
-    locales iputils-ping gettext fontconfig libc6 libfreetype6 libjpeg-turbo8 \
-    libpng16-16 libssl3 libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 \
+    locales iputils-ping gettext fontconfig libc6 libfreetype6 libjpeg62-turbo \
+    libpng16-16 libssl-dev libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 \
     libxrender1 libxi6 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
     nano openssh-client vim-tiny \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,6 @@
         <slf4j.version>1.7.32</slf4j.version>
         <hapifhir.version>5.4.0</hapifhir.version>
         <struts.version>1.3.11</struts.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
         <slf4j.version>1.7.32</slf4j.version>
         <hapifhir.version>5.4.0</hapifhir.version>
         <struts.version>1.3.11</struts.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <repositories>
@@ -1431,12 +1433,22 @@
             <version>4.4.1</version>
         </dependency>
         <!-- Coming soon: JAVA 11 -->
-        <!--<dependency>-->
-        <!--    <groupId>com.sun.xml.ws</groupId>-->
-        <!--    <artifactId>jaxws-ri</artifactId>-->
-        <!--    <version>2.3.0</version>-->
-        <!--    <type>pom</type>-->
-        <!--</dependency>-->
+        <dependency>
+           <groupId>com.sun.xml.ws</groupId>
+           <artifactId>jaxws-ri</artifactId>
+           <version>2.3.0</version>
+           <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
@@ -1534,8 +1546,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1434,7 +1434,7 @@
         <dependency>
            <groupId>com.sun.xml.ws</groupId>
            <artifactId>jaxws-ri</artifactId>
-           <version>2.3.0</version>
+           <version>2.3.3</version>
            <type>pom</type>
         </dependency>
         <dependency>
@@ -1446,6 +1446,12 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
+        </dependency>
+         <!-- Added for Tomcat9.0.97 -->
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.3</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
New PR for Java 11. Same commits.

## Summary by Sourcery

Upgrade the project to Java 11 by updating dependencies and Maven compiler settings, and modify the Dockerfile to use a Java 11 base image.

Enhancements:
- Upgrade project dependencies to support Java 11, including jaxws-ri, jaxb-api, javax.annotation-api, and jaxb-impl.
- Update Maven compiler plugin configuration to use Java 11 as the source and target version.

Build:
- Modify Dockerfile to use openjdk:11-jdk-slim as the base image and configure Tomcat environment variables.