### PR TITLE
Refer to project as OpenOSP

### DIFF
--- a/src/test/resources/over_ride_config.properties.template
+++ b/src/test/resources/over_ride_config.properties.template
@@ -9,7 +9,7 @@ db_password=password
 db_url_prefix=jdbc:mysql://db/
 # zeroDateTimeBehavior: Change the behavior of date 0000-00-00 to automatically become a valid date by rounding. The
 #                       new default is to throw an exception, whereas previous versions of Connector/J converted to
-#                       null. For type safety and to lower the number of exceptions thrown by OSCAR, round is the
+#                       null. For type safety and to lower the number of exceptions thrown by OpenOSP, round is the
 #                       logical choice.
 # useOldAliasMetadataBehavior: Due to issues with Hibernate column mapping, queries which rename columns will cause
 #                              Hibernate to throw an exception. Previous version of Connector/J used a different
@@ -17,7 +17,7 @@ db_url_prefix=jdbc:mysql://db/
 # jdbcCompliantTruncation: Fields which are not included in a query, and do not contain a default value in the database,
 #                          will raise an exception in the JDBC specification. Previous versions of Connector/J
 #                          were not JDBC compliant and did not follow the truncation specifications.
-# IMPORTANT: The fields listed after the ? are required! Otherwise, OSCAR will not behave properly as it depends on
+# IMPORTANT: The fields listed after the ? are required! Otherwise, OpenOSP will not behave properly as it depends on
 #            legacy functionality. Ensure that you leave the tags behind the field when renaming the database.
 db_schema_properties=?zeroDateTimeBehavior=round&useOldAliasMetadataBehavior=true&jdbcCompliantTruncation=false&useSSL=false
 db_schema=oscar_test


### PR DESCRIPTION
## Changes made
- Change all references to project as OpenOSP in `over_ride_config.properties.template` file.