### PR TITLE
StringBuilder fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1524,8 +1524,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/oscarehr/common/model/AbstractModel.java
+++ b/src/main/java/org/oscarehr/common/model/AbstractModel.java
@@ -25,7 +25,7 @@ package org.oscarehr.common.model;
 
 import java.util.List;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.oscarehr.util.MiscUtils;
 
 public abstract class AbstractModel<T> implements java.io.Serializable {

--- a/src/main/java/org/oscarehr/common/model/Drug.java
+++ b/src/main/java/org/oscarehr/common/model/Drug.java
@@ -42,8 +42,8 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import oscar.oscarRx.data.RxPrescriptionData;
 import oscar.oscarRx.util.RxUtil;

--- a/src/main/java/org/oscarehr/ws/rest/to/model/PreventionSearchTo1.java
+++ b/src/main/java/org/oscarehr/ws/rest/to/model/PreventionSearchTo1.java
@@ -28,7 +28,7 @@ package org.oscarehr.ws.rest.to.model;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 public class PreventionSearchTo1 {
 

--- a/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/config/pageUtil/EctConAddSpecialist2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/config/pageUtil/EctConAddSpecialist2Action.java
@@ -32,7 +32,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.logging.log4j.Logger;;
+import org.apache.logging.log4j.Logger;
 import org.oscarehr.common.dao.ProfessionalSpecialistDao;
 import org.oscarehr.common.model.ProfessionalSpecialist;
 import org.oscarehr.managers.SecurityInfoManager;


### PR DESCRIPTION
## Changes made
This PR has a few last minute fixes we've been meaning to make in bullfrog. These include:
- Import `apache.commons.lang3` instead of `apache.commons.lang` for StringBuilder and ReflectionToStringBuilder in several classes.
  - The `lang3` version fixes several failing unit tests.
- Targeting Java 21 in the maven compiler plugin
- Fixing a double semi-colon type in `EctConEditSpecialists2Action.java`

## Summary by Sourcery

Fix import statements to use 'apache.commons.lang3' for StringBuilder and ReflectionToStringBuilder, update Maven compiler plugin to target Java 21, and correct a typo in 'EctConEditSpecialists2Action.java'.

Bug Fixes:
- Correct import statements to use 'apache.commons.lang3' instead of 'apache.commons.lang' for StringBuilder and ReflectionToStringBuilder, resolving several failing unit tests.
- Fix a typo involving a double semi-colon in 'EctConEditSpecialists2Action.java'.

Build:
- Update the Maven compiler plugin to target Java 21.