### PR TITLE
build: change development docker image, install libjpeg62

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM tomcat:9.0.97-jdk21-temurin
 
 # Set environment variables for Tomcat
 ENV CATALINA_HOME /usr/local/tomcat
@@ -23,8 +23,8 @@ WORKDIR /workspace
 # Install required packages and clean up apt lists
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dos2unix curl git wget apt-transport-https ca-certificates gnupg lsb-release \
-    locales iputils-ping gettext fontconfig libc6 libfreetype6 libjpeg62-turbo \
-    libpng16-16 libssl-dev libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 \
+    locales iputils-ping gettext fontconfig libc6 libfreetype6 \
+    libpng16-16 libssl-dev libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 libjpeg62 \
     libxrender1 libxi6 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
     nano openssh-client vim-tiny \
     && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Changes made
- Change docker image to `tomcat:9.0.97-jdk21-temurin`.
- Install `libjpeg62` instead of `libjpeg62-turbo`.