### PR TITLE
fix: update jna dependency version to 5.17.0 and update integrity hash

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1083,11 +1083,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.16.0",
+    "version" : "5.17.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:2eGpxL6mstiqyWAdCXp3AT/TI7b1xh2D+sIZirapiLXPITkGGJM7FD3kzCVthL0qhnmPyzZ5R5zPxq7LIDQZhA=="
+    "integrity" : "sha512:M/NSUo/HCgf/yRhP+AZHsCxR6ibOsRznDupK29lBmm+BG8EXRtxz3fQP8qIdrtvqq9NJ6QHzDsXoQaH1/G8bUg=="
   }, {
     "groupId" : "net.oauth.core",
     "artifactId" : "oauth-provider",


### PR DESCRIPTION
When I use 6bc4e1c3c2c8ca3fccb3ce1eb1e306334ecf07ad as base and ran `make install` command in my dev container, I ran into this issue:
```
[INFO] --- dependency-lock-maven-plugin:1.1.0:check (check) @ oscar ---
[ERROR] The following dependencies differ:
[ERROR]   Expected net.java.dev.jna:jna:jar:5.16.0:compile:optional=false@sha512:2eGpxL6mstiqyWAdCXp3AT/TI7b1xh2D+sIZirapiLXPITkGGJM7FD3kzCVthL0qhnmPyzZ5R5zPxq7LIDQZhA== but found net.java.dev.jna:jna:jar:5.17.0:compile:optional=false@sha512:M/NSUo/HCgf/yRhP+AZHsCxR6ibOsRznDupK29lBmm+BG8EXRtxz3fQP8qIdrtvqq9NJ6QHzDsXoQaH1/G8bUg==, wrong integrity and version
```

After I ran the `mvn se.vandmo:dependency-lock-maven-plugin:lock` command to regenerate the lock file, the `make install` command succeed in my dev container.


The full output of the error of make install for your reference:
```
root@bce26825a0ea:/workspace# make install
Using CATALINA_BASE:   /usr/local/tomcat
Using CATALINA_HOME:   /usr/local/tomcat
Using CATALINA_TMPDIR: /usr/local/tomcat/temp
Using JRE_HOME:        /opt/java/openjdk
Using CLASSPATH:       /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
Using CATALINA_OPTS:   --add-opens java.base/java.net=ALL-UNNAMED
NOTE: Picked up JDK_JAVA_OPTIONS:  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
Mar 17, 2025 4:59:24 PM org.apache.catalina.startup.Catalina stopServer
SEVERE: Could not contact [localhost:8005] (base port [8005] and offset [0]). Tomcat may not be running.
Mar 17, 2025 4:59:24 PM org.apache.catalina.startup.Catalina stopServer
SEVERE: Error stopping Catalina
java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.Net.connect0(Native Method)
        at java.base/sun.nio.ch.Net.connect(Net.java:589)
        at java.base/sun.nio.ch.Net.connect(Net.java:578)
        at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:583)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
        at java.base/java.net.Socket.connect(Socket.java:751)
        at java.base/java.net.Socket.connect(Socket.java:686)
        at java.base/java.net.Socket.<init>(Socket.java:555)
        at java.base/java.net.Socket.<init>(Socket.java:324)
        at org.apache.catalina.startup.Catalina.stopServer(Catalina.java:629)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.apache.catalina.startup.Bootstrap.stopServer(Bootstrap.java:393)
        at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:478)

Killing Tomcat/Java PID: 5544
/scripts/server: 26: kill: No such process

Setting up over_ride_config_properties...
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.oscarehr:oscar:war:0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin se.vandmo:dependency-lock-maven-plugin @ line 1635, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] Using the MultiThreadedBuilder implementation with a thread count of 12
[INFO] 
[INFO] -------------------------< org.oscarehr:oscar >-------------------------
[INFO] Building OpenO 0-SNAPSHOT
[INFO] --------------------------------[ war ]---------------------------------
[WARNING] The POM for com.sun.xml.bind:jaxb-xjc:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for com.sun.xml.bind:jaxb-core:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for com.sun.xml.bind:jaxb-impl:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The artifact mysql:mysql-connector-java:jar:8.0.33 has been relocated to com.mysql:mysql-connector-j:jar:8.0.33: MySQL Connector/J artifacts moved to reverse-DNS compliant Maven 2+ coordinates.
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ oscar ---
[INFO] 
[INFO] --- buildnumber-maven-plugin:3.2.0:create (default) @ oscar ---
[INFO] Executing: /bin/sh -c cd '/workspace' && 'git' 'rev-parse' '--verify' 'HEAD'
[INFO] Working directory: /workspace
[INFO] Storing buildNumber: 6bc4e1c3c2c8ca3fccb3ce1eb1e306334ecf07ad at timestamp: 1742245165681
[INFO] Executing: /bin/sh -c cd '/workspace' && 'git' 'symbolic-ref' 'HEAD'
[INFO] Working directory: /workspace
[INFO] Storing scmBranch: develop/coyote
[INFO] 
[INFO] --- build-helper-maven-plugin:3.0.0:timestamp-property (timestamp-property) @ oscar ---
[INFO] 
[INFO] --- dependency-lock-maven-plugin:1.1.0:check (check) @ oscar ---
[ERROR] The following dependencies differ:
[ERROR]   Expected net.java.dev.jna:jna:jar:5.16.0:compile:optional=false@sha512:2eGpxL6mstiqyWAdCXp3AT/TI7b1xh2D+sIZirapiLXPITkGGJM7FD3kzCVthL0qhnmPyzZ5R5zPxq7LIDQZhA== but found net.java.dev.jna:jna:jar:5.17.0:compile:optional=false@sha512:M/NSUo/HCgf/yRhP+AZHsCxR6ibOsRznDupK29lBmm+BG8EXRtxz3fQP8qIdrtvqq9NJ6QHzDsXoQaH1/G8bUg==, wrong integrity and version
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.372 s (Wall Clock)
[INFO] Finished at: 2025-03-17T16:59:26-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal se.vandmo:dependency-lock-maven-plugin:1.1.0:check (check) on project oscar: Dependencies differ -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Using CATALINA_BASE:   /usr/local/tomcat
Using CATALINA_HOME:   /usr/local/tomcat
Using CATALINA_TMPDIR: /usr/local/tomcat/temp
Using JRE_HOME:        /opt/java/openjdk
Using CLASSPATH:       /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
Using CATALINA_OPTS:   --add-opens java.base/java.net=ALL-UNNAMED
Tomcat started.
Tomcat/Java PID: 1120
```

## Summary by Sourcery

Bug Fixes:
- Fixes a dependency check error caused by a mismatch between the expected and actual versions of the jna dependency.