### PR TITLE
doc: update README for subsequent compilations and view oscar error logs from terminal

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -58,6 +58,15 @@ Exploded WAR".
     * Open your web browser and navigate to `http://localhost:8080`.
     * You should see the Open-OSP EMR application running.
 
+### Subsequent Compilations
+
+For developers who are not compiling for the first time in the dev container, it is recommended to clean the previous build artifacts before compiling again. This ensures a fresh build environment.
+
+   ```zsh
+   make clean
+   make install
+   ```
+
 ## Additional Notes
 
 * The `.devcontainer/development/config/shared/local.env` file contains environment variables that can be customized for

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -67,6 +67,13 @@ For developers who are not compiling for the first time in the dev container, it
    make install
    ```
 
+### View Oscar error logs
+
+Currently, oscar error logs are sent to console without saving to a log file. If you need to read oscar error logs from dev container, can use this command to see real-time logs.
+   ```zsh
+   cat /tomcat.pid | xargs -I {} tail -f /proc/{}/fd/1
+   ```
+
 ## Additional Notes
 
 * The `.devcontainer/development/config/shared/local.env` file contains environment variables that can be customized for

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -70,6 +70,7 @@ For developers who are not compiling for the first time in the dev container, it
 ### View Oscar error logs
 
 Currently, oscar error logs are sent to console without saving to a log file. If you need to read oscar error logs from dev container, can use this command to see real-time logs.
+
    ```zsh
    cat /tomcat.pid | xargs -I {} tail -f /proc/{}/fd/1
    ```


### PR DESCRIPTION
I always run `make install` to build the Oscar project, but sometimes Maven throws an error about the target folder exists or can't delete the Tomcat webapp folder. 
So I used ```
rm -rvf /workspace/target/classes && rm -rvf /usr/local/tomcat/webapps/oscar/ && make install``` all the time. 
But I found the `make clean` command does pretty much the same.

So I propose this improvement in the README.md that can just use two simple commands `make clean` and `make install` to prevent any unwanted surprises during development in the dev container.

Update: added guidance of how to view oscar logs from dev container terminal

## Summary by Sourcery

Documentation:
- Recommend using `make clean` before `make install` for subsequent compilations.