### PR TITLE
fix: Session Fixation (OWASP A07:2021 – Identification and Authentication Failures)

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -411,7 +411,7 @@ public class CaseManagementEntry2Action extends ActionSupport {
         String ipAddress = request.getRemoteAddr();
         CasemgmtNoteLock casemgmtNoteLock;
         Long note_id = note.getId() != null && note.getId() >= 0 ? note.getId() : 0L;
-        casemgmtNoteLock = isNoteEdited(note_id, demographicNo, providerNo, ipAddress, request.getRequestedSessionId());
+        casemgmtNoteLock = isNoteEdited(note_id, demographicNo, providerNo, ipAddress, request.getSession().getId());
 
         if (casemgmtNoteLock.isLocked()) {
             note = makeNewNote(providerNo, demono, request);
@@ -518,7 +518,7 @@ public class CaseManagementEntry2Action extends ActionSupport {
         String demoNo = getDemographicNo(request);
         String noteId = request.getParameter("noteId");
         String ipAddress = request.getRemoteAddr();
-        String sessionId = request.getRequestedSessionId();
+        String sessionId = request.getSession().getId();
 
         logger.debug("WEB isNoteEdited CALLED");
         CasemgmtNoteLock casemgmtNoteLock = isNoteEdited(Long.parseLong(noteId), Integer.parseInt(demoNo), providerNo, ipAddress, sessionId);
@@ -553,7 +553,7 @@ public class CaseManagementEntry2Action extends ActionSupport {
         }
 
         casemgmtNoteLock.setIpAddress(request.getRemoteAddr());
-        casemgmtNoteLock.setSessionId(request.getRequestedSessionId());
+        casemgmtNoteLock.setSessionId(request.getSession().getId());
         logger.debug("UPDATING LOCK DEMO " + demoNo + " SESSION " + casemgmtNoteLock.getSessionId() + " LOCK IP " + casemgmtNoteLock.getIpAddress());
         casemgmtNoteLockDao.merge(casemgmtNoteLock);
 
@@ -1172,8 +1172,8 @@ public class CaseManagementEntry2Action extends ActionSupport {
 
             CasemgmtNoteLock casemgmtNoteLock = casemgmtNoteLockDao.find(casemgmtNoteLockSession.getId());
             //if other window has acquired lock we reject save
-            if (!casemgmtNoteLock.getSessionId().equals(casemgmtNoteLockSession.getSessionId()) || !request.getRequestedSessionId().equals(casemgmtNoteLockSession.getSessionId())) {
-                logger.debug("DO NOT HAVE LOCK FOR " + demo + " PROVIDER " + providerNo + " CONTINUE SAVING LOCAL SESSION " + request.getRequestedSessionId() + " LOCAL IP " + request.getRemoteAddr() + " LOCK SESSION " + casemgmtNoteLockSession.getSessionId() + " LOCK IP " + casemgmtNoteLockSession.getIpAddress());
+            if (!casemgmtNoteLock.getSessionId().equals(casemgmtNoteLockSession.getSessionId()) || !request.getSession().getId().equals(casemgmtNoteLockSession.getSessionId())) {
+                logger.debug("DO NOT HAVE LOCK FOR " + demo + " PROVIDER " + providerNo + " CONTINUE SAVING LOCAL SESSION " + request.getSession().getId() + " LOCAL IP " + request.getRemoteAddr() + " LOCK SESSION " + casemgmtNoteLockSession.getSessionId() + " LOCK IP " + casemgmtNoteLockSession.getIpAddress());
                 return -1L;
             }
         } catch (Exception e) {
@@ -1832,7 +1832,7 @@ public class CaseManagementEntry2Action extends ActionSupport {
         try {
             CasemgmtNoteLock casemgmtNoteLockSession = (CasemgmtNoteLock) session.getAttribute("casemgmtNoteLock" + demoNo);
             //If browser is exiting check to see if we should release lock.  It may be held by same user in another window so we check
-            if (request.getRequestedSessionId().equals(casemgmtNoteLockSession.getSessionId()) && casemgmtNoteLockSession.getNoteId() == Long.parseLong(noteId)) {
+            if (request.getSession().getId().equals(casemgmtNoteLockSession.getSessionId()) && casemgmtNoteLockSession.getNoteId() == Long.parseLong(noteId)) {
                 releaseNoteLock(providerNo, Integer.parseInt(demoNo), Long.parseLong(noteId));
                 session.removeAttribute("casemgmtNoteLock" + demoNo);
             }


### PR DESCRIPTION
Open-O using a session ID provided directly by the client through the HttpServletRequest.getRequestedSessionId() method. According to the Java Servlet API documentation, this method returns the session ID specified by the client, which may not correspond to the current valid session. As session IDs can be transmitted through cookies or URL parameters, attackers can easily manipulate this session ID value.