### PR TITLE
Fix 500 error when deleting provider.

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -1034,11 +1034,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.15.0",
+    "version" : "5.17.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Nfr+zgyK+pXglOfGJ4ANDOAky/1bZxEHV+sw1F3PwxB+q3Wvn+xJi2Kfm3kLKviSegk6coPTSPeyEPRTPPd8og=="
+    "integrity" : "sha512:M/NSUo/HCgf/yRhP+AZHsCxR6ibOsRznDupK29lBmm+BG8EXRtxz3fQP8qIdrtvqq9NJ6QHzDsXoQaH1/G8bUg=="
   }, {
     "groupId" : "net.oauth.core",
     "artifactId" : "oauth-provider",
@@ -2831,7 +2831,7 @@
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:PvzT/NBtwvDq1wzkQbzpdtEF9Tuq+A4SHjcNo35rSZjjoJKvrF1W9EEgNMZpQGQWut4qE30/4/z10fG6rW4KJg=="
+    "integrity" : "sha512:KuYiGULJjM5+QXyYP/PbuWVkuls1Wx2pZ2wCv2aUzB2uHUdta31bz2Qhux4BtN/hrd5IB3q0nBXb80K7GAGWAw=="
   }, {
     "groupId" : "org.oscarehr.caisi_integrator",
     "artifactId" : "caisi_integrator_client_stubs",
@@ -2855,7 +2855,7 @@
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:2xrsBje+ruyGvYWUGVlyWQUigf5AkrklTZ91J17+5puAPmicjZs99s9qV4r9jkx3myupstPvc3Q8y7WTmsvBMw=="
+    "integrity" : "sha512:6IiX6yzoQZ9SEf3kdtJUI2LeFOWSrk5X51EZlIhMD4lH0G+CXoHXAeQSDxqGZsa9s5nGLFJF6EuCytSo4wWbbQ=="
   }, {
     "groupId" : "org.oscarehr.hrm",
     "artifactId" : "hrm-jaxb",

--- a/src/main/java/com/quatro/dao/security/SecuserroleDaoImpl.java
+++ b/src/main/java/com/quatro/dao/security/SecuserroleDaoImpl.java
@@ -68,7 +68,7 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
     public void saveAll(List list) {
         logger.debug("saving ALL Secuserrole instances");
         // Session session = getSession();
-        Session session = currentSession();;
+        Session session = currentSession();
         try {
             for (int i = 0; i < list.size(); i++) {
                 Secuserrole obj = (Secuserrole) list.get(i);
@@ -167,9 +167,10 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
     public int deleteById(Integer id) {
         logger.debug("deleting Secuserrole by ID");
         try {
-
-            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.id =?", id);
-
+            Session session = currentSession();
+            Secuserrole entity = session.get(Secuserrole.class, id);
+            this.delete(entity);
+            return 1;
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
             throw re;

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAOImpl.java
@@ -38,6 +38,7 @@ import org.oscarehr.util.QueueCache;
 import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 public class ProgramProviderDAOImpl extends HibernateDaoSupport implements ProgramProviderDAO {
 
     private Logger log = MiscUtils.getLogger();
@@ -201,6 +202,7 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
     }
 
     @Override
+    @Transactional(readOnly = false)
     public void deleteProgramProvider(Long id) {
         if (id == null || id.intValue() < 0) {
             throw new IllegalArgumentException();
@@ -218,6 +220,7 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
     }
 
     @Override
+    @Transactional(readOnly = false)
     public void deleteProgramProviderByProgramId(Long programId) {
         if (programId == null || programId.intValue() <= 0) {
             throw new IllegalArgumentException();


### PR DESCRIPTION
## Changes made
This PR fixes issue #143. The fixes include:
 - Replacing getHibernateTemplate().bulkUpdate() with session.delete() in SecuserroleDaoImpl.java.
 - Adding hibernate transactional tags to ProgramProviderDAOImpl.java.

## Summary by Sourcery

Fix database operation issues when deleting providers by improving Hibernate transaction handling and deletion methods

Bug Fixes:
- Resolved 500 error when deleting providers by replacing bulk update with direct session-based deletion in SecuserroleDaoImpl
- Fixed potential transaction-related issues in ProgramProviderDAOImpl by adding proper transactional annotations

Enhancements:
- Improved database deletion method to use direct session deletion instead of bulk update
- Added explicit transactional configuration to DAO methods