### PR TITLE
Enable debugging in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
         }
     },
 
-    "forwardPorts": [8080, 3306],
+    "forwardPorts": [8080, 8000, 3306],
     "containerUser": "root",
     "remoteUser": "root"
 }

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -3,7 +3,7 @@ FROM tomcat:9.0.97-jdk21-temurin
 # Set environment variables for Tomcat
 ENV CATALINA_HOME /usr/local/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
-ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED"
+ENV CATALINA_OPTS="--add-opens java.base/java.net=ALL-UNNAMED -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n"
 
 # Copy Tomcat installation from the official Tomcat image
 COPY --from=tomcat:9.0.97 /usr/local/tomcat $CATALINA_HOME

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+      - "8000:8000"
     volumes:
       - m2-volume:/root/.m2
       - ..:/workspace:cached 


### PR DESCRIPTION
## Changes made
Enabled remote debugging in the devcontainer.
- Add new flags to `CATALINA_OPTS`.
- Expose port 8000 in the devcontainer.

## Summary by Sourcery

Configure remote debugging for the development container

Enhancements:
- Add remote debugging configuration to the Tomcat development environment

Deployment:
- Expose debugging port 8000 in the development container

Chores:
- Update Dockerfile and docker-compose configuration to support remote debugging