### PR TITLE
Comment out failing FhirMessageBuilder test

### DIFF
--- a/src/test/java/org/oscarehr/integration/fhir/builder/FhirMessageBuilderTest.java
+++ b/src/test/java/org/oscarehr/integration/fhir/builder/FhirMessageBuilderTest.java
@@ -175,55 +175,72 @@ public class FhirMessageBuilderTest {
 
 
     /*
+     * UPDATE
+     * April 24, 2025
+     * sebastian-j-ibanez
+     * 
+     * This test has been commented out, due to several fixes needed.
+     * The test throws an initialization exception from
+     * the fhir.builder.SenderFactory class.
+     * 
+     * This is because the SenderFactory statically initializes a ClinicDAO field.
+     * 
+     * The recommended fix is:
+     * 1. Make FhirMessageBuilderTest extend DaoTestFixtures
+     *    (to initialize SpringUtils.beanFactory)
+     * 2. Add the `clinic` table to oscar_test.
+     * 
+     * UPDATE END
+     *
      * BIS formatted messages use a Communication resource.
      */
-    @Test
-    public void testGetBISFormattedMessage() {
+    // @Test
+    // public void testGetBISFormattedMessage() {
 
-        System.out.println(">>>-- testGetBISFormattedMessage() -->");
-        System.out.println();
+    //     System.out.println(">>>-- testGetBISFormattedMessage() -->");
+    //     System.out.println();
 
-        LoggedInInfo loggedInInfo = new LoggedInInfo();
-        Security security = new Security();
-        security.setOneIdEmail("oneid@oneidemail.com");
-        loggedInInfo.setLoggedInProvider(provider);
-        loggedInInfo.setLoggedInSecurity(security);
+    //     LoggedInInfo loggedInInfo = new LoggedInInfo();
+    //     Security security = new Security();
+    //     security.setOneIdEmail("oneid@oneidemail.com");
+    //     loggedInInfo.setLoggedInProvider(provider);
+    //     loggedInInfo.setLoggedInSecurity(security);
 
-        Settings settings = new Settings(FhirDestination.BORN, Region.ON);
+    //     Settings settings = new Settings(FhirDestination.BORN, Region.ON);
 
-        OscarFhirConfigurationManager configurationManager = new OscarFhirConfigurationManager(loggedInInfo, settings);
-        // normally this is done inside the Configuration manager but this test will not instantiate a DAO
-        configurationManager.getSender().setClinic(clinic);
+    //     OscarFhirConfigurationManager configurationManager = new OscarFhirConfigurationManager(loggedInInfo, settings);
+    //     // normally this is done inside the Configuration manager but this test will not instantiate a DAO
+    //     configurationManager.getSender().setClinic(clinic);
 
-        Patient patient = new Patient(demographic, configurationManager);
-        Practitioner practitioner = new Practitioner(provider, configurationManager);
+    //     Patient patient = new Patient(demographic, configurationManager);
+    //     Practitioner practitioner = new Practitioner(provider, configurationManager);
 
-        // Get the ClinicalImpresson as the Attachment resource for this message. ClinicalImpression is created
-        // to automatically map patient medical annotations. In this case it is being customized after instantiation.
-        ClinicalImpression clinicalImpression = new ClinicalImpression("<xml>This is a test of a clinical annotation</xml>");
-        clinicalImpression.setDescription("Well Baby");
+    //     // Get the ClinicalImpresson as the Attachment resource for this message. ClinicalImpression is created
+    //     // to automatically map patient medical annotations. In this case it is being customized after instantiation.
+    //     ClinicalImpression clinicalImpression = new ClinicalImpression("<xml>This is a test of a clinical annotation</xml>");
+    //     clinicalImpression.setDescription("Well Baby");
 
-        // The communication.sender attribute is set automatically.
-        FhirCommunicationBuilder fhirCommunicationBuilder = new FhirCommunicationBuilder(configurationManager);
+    //     // The communication.sender attribute is set automatically.
+    //     FhirCommunicationBuilder fhirCommunicationBuilder = new FhirCommunicationBuilder(configurationManager);
 
-        // this one is tricky.  The patient's managing organization Organization resource is contained inside the Communication resource.
-        // and is also represented as the Communication.sender.  So the link needs to be external.
-        // patient.setManagingOrganizationReference( SenderFactory.getSender().getOscarFhirResource().getContainedReferenceLink() );
+    //     // this one is tricky.  The patient's managing organization Organization resource is contained inside the Communication resource.
+    //     // and is also represented as the Communication.sender.  So the link needs to be external.
+    //     // patient.setManagingOrganizationReference( SenderFactory.getSender().getOscarFhirResource().getContainedReferenceLink() );
 
-        // Practitioner is referenced from inside the patient. It is contained inside the Communication resource.
-        patient.addGeneralPractitionerReference(practitioner.getContainedReferenceLink());
-        fhirCommunicationBuilder.addResource(practitioner);
+    //     // Practitioner is referenced from inside the patient. It is contained inside the Communication resource.
+    //     patient.addGeneralPractitionerReference(practitioner.getContainedReferenceLink());
+    //     fhirCommunicationBuilder.addResource(practitioner);
 
-        // Patient is contained in the communication.subject attribute
-        fhirCommunicationBuilder.setSubject(patient);
+    //     // Patient is contained in the communication.subject attribute
+    //     fhirCommunicationBuilder.setSubject(patient);
 
-        // The Attachment resource can be copied from the ClinicalImpression resource.
-        // an Attachment can also be added directly through 1 of 4 methods. I.E.:
-        // fhirCommunicationBuilder.attachXML( "<xml>This is a test of a clinical annotation</xml>" , "Well Baby" );
-        fhirCommunicationBuilder.addAttachment(clinicalImpression.copyToAttachement(new Attachment()));
+    //     // The Attachment resource can be copied from the ClinicalImpression resource.
+    //     // an Attachment can also be added directly through 1 of 4 methods. I.E.:
+    //     // fhirCommunicationBuilder.attachXML( "<xml>This is a test of a clinical annotation</xml>" , "Well Baby" );
+    //     fhirCommunicationBuilder.addAttachment(clinicalImpression.copyToAttachement(new Attachment()));
 
-        System.out.println(fhirCommunicationBuilder.getMessageJson());
-    }
+    //     System.out.println(fhirCommunicationBuilder.getMessageJson());
+    // }
 
     // @Test
     public void testGetDHIRFormattedMessage() {


### PR DESCRIPTION
## Changes made
- Commented out `testGetBISFormattedMessage()`
- Left doc comment explaining reason that test is failing, with proposed fix.

### Comment Explanation
```java
    /*
     * UPDATE
     * April 24, 2025
     * sebastian-j-ibanez
     * 
     * This test has been commented out, due to several fixes needed.
     * The test throws an initialization exception from
     * the fhir.builder.SenderFactory class.
     * 
     * This is because the SenderFactory statically initializes a ClinicDAO field.
     * 
     * The recommended fix is:
     * 1. Make FhirMessageBuilderTest extend DaoTestFixtures
     *    (to initialize SpringUtils.beanFactory)
     * 2. Add the `clinic` table to oscar_test.
     * 
     * UPDATE END
     *
     * BIS formatted messages use a Communication resource.
     */
     ```