### PR TITLE
fix: resolve JSP syntax errors in multiple files

### DIFF
--- a/src/main/webapp/admin/adminbackupdownload.jsp
+++ b/src/main/webapp/admin/adminbackupdownload.jsp
@@ -25,26 +25,31 @@
 
 --%>
 
-<%@ page contentType="text/html; charset=UTF-8"%>
+<%@ page contentType="text/html; charset=UTF-8" errorPage="/errorpage.jsp" %>
 <%@ page import="
-    java.util.*,
-    oscar.*,
-    java.io.*,
-    java.net.*,
-    oscar.util.*,
-    org.apache.commons.io.FileUtils"
-    errorPage="/errorpage.jsp"
-%>
+      java.util.*,
+      java.io.*,
+      java.net.*,
+      org.apache.commons.io.FileUtils,
+      org.apache.commons.text.StringEscapeUtils,
+      oscar.OscarProperties,
+      oscar.util.FileSortByDate
+" %>
 
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core"   prefix="c"   %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt"    prefix="fmt" %>
 
 <%
-    // --- Security check with null-safe session attributes ---
-    String userRole = String.valueOf(session.getAttribute("userrole"));
-    String userName = String.valueOf(session.getAttribute("user"));
-    String roleName$ = userRole + "," + userName;
+    // 1) Null-safe session check
+    String userRoleAttr = (String) session.getAttribute("userrole");
+    String userNameAttr = (String) session.getAttribute("user");
+    if (userRoleAttr == null || userNameAttr == null) {
+        // no session info → bounce to login
+        response.sendRedirect(request.getContextPath() + "/login.jsp");
+        return;
+    }
+    String roleName$ = userRoleAttr + "," + userNameAttr;
     boolean authed = true;
 %>
 <security:oscarSec
@@ -52,9 +57,9 @@
     objectName="_admin,_admin.backup"
     rights="r"
     reverse="true">
-  <% 
-      authed = false;
-      response.sendRedirect("../securityError.jsp?type=_admin&type=_admin.backup");
+  <%
+    authed = false;
+    response.sendRedirect("../securityError.jsp?type=_admin&type=_admin.backup");
   %>
 </security:oscarSec>
 <%
@@ -64,20 +69,28 @@
 %>
 
 <%
-    // --- Load backup_path from OscarProperties singleton ---
-    Properties oscarVariables = OscarProperties.getInstance();
-    String backuppath = oscarVariables.getProperty("backup_path");
+    // Load backup_path
+    Properties oscarVars = OscarProperties.getInstance();
+    String backuppath = oscarVars.getProperty("backup_path");
     session.setAttribute("backupfilepath", backuppath);
 
     File dir = new File(backuppath);
     boolean exists = dir.exists();
 %>
 
+<c:set var="calendarLangKey">
+  <fmt:message key="global.javascript.calendar"/>
+</c:set>
+<c:url value="/share/calendar/lang/${calendarLangKey}" var="calendarLangUrl"/>
+
 <html>
   <head>
     <title>Admin Backup Download</title>
-    <link href="<%= request.getContextPath() %>/css/bootstrap.min.css" rel="stylesheet">
-    <link href="<%= request.getContextPath() %>/css/font-awesome.min.css" rel="stylesheet">
+    <link href="<%= request.getContextPath() %>/css/bootstrap.min.css" rel="stylesheet"/>
+    <link href="<%= request.getContextPath() %>/css/font-awesome.min.css" rel="stylesheet"/>
+    <script type="text/javascript"
+            src="${pageContext.request.contextPath}${calendarLangUrl}">
+    </script>
   </head>
   <body>
     <h3>
@@ -89,27 +102,24 @@
       <div class="well">
         <table class="table table-striped table-condensed">
           <thead>
-            <tr>
-              <th>File Name</th>
-              <th>Size</th>
-            </tr>
+            <tr><th>File Name</th><th>Size</th></tr>
           </thead>
           <tbody>
           <%
-              // Validate backup_path
+              // missing or empty path → forward to error
               if (backuppath == null || backuppath.isEmpty()) {
                   request.setAttribute("errorMessage",
-                      "backup_path is missing in properties; please configure it.");
-                  request.getRequestDispatcher("/error.jsp").forward(request, response);
+                    "backup_path missing in properties; please configure.");
+                  request.getRequestDispatcher("/error.jsp")
+                         .forward(request, response);
                   return;
               }
 
-              // List, sort & display
               File[] contents = dir.listFiles();
               if (contents == null || contents.length == 0) {
                   throw new Exception(
-                    "No files found in directory " + backuppath +
-                    ". Please correct backup_path if necessary."
+                    "No files found in " + backuppath +
+                    ". Please correct backup_path."
                   );
               }
               Arrays.sort(contents, new FileSortByDate());
@@ -122,18 +132,19 @@
                       continue;
                   }
 
+                  // 2) XSS-safe name
+                  String safeName = StringEscapeUtils.escapeHtml4(name);
+
                   String encoded = URLEncoder.encode(name, "UTF-8");
                   long bytes = f.length();
                   String displaySize = FileUtils.byteCountToDisplaySize(bytes);
 
                   out.println(
                     "<tr>" +
-                      "<td>" +
-                        "<a href=\"" + request.getContextPath() +
-                          "/servlet/BackupDownload?filename=" + encoded + "\">" +
-                          name +
-                        "</a>" +
-                      "</td>" +
+                      "<td><a href=\"" + request.getContextPath() +
+                        "/servlet/BackupDownload?filename=" + encoded + "\">" +
+                        safeName +
+                      "</a></td>" +
                       "<td align=\"right\" title=\"" + bytes + " bytes\">" +
                         displaySize +
                       "</td>" +
@@ -144,14 +155,11 @@
           </tbody>
         </table>
       </div>
-
     <% } else { %>
       <div class="alert alert-error">
         <strong>Warning!</strong>
-        Your backup directory does not exist or path is invalid.
-        Please check <i>backup_path</i> in your properties file.
+        Backup directory not found—check <i>backup_path</i> in your properties.
       </div>
     <% } %>
-
   </body>
 </html>

--- a/src/main/webapp/admin/adminbackupdownload.jsp
+++ b/src/main/webapp/admin/adminbackupdownload.jsp
@@ -94,10 +94,11 @@
 <%
     // Validate backup_path
     if (backuppath == null || backuppath.isEmpty()) {
-        throw new Exception(
-          "Unable to find the key backup_path in the properties file. " +
-          "Please check the value of this key or add it if it is missing."
-        );
+        String errorMessage = "Unable to find the key backup_path in the properties file. " +
+                              "Please check the value of this key or add it if it is missing.";
+        request.setAttribute("errorMessage", errorMessage);
+        request.getRequestDispatcher("/error.jsp").forward(request, response);
+        return;
     }
 
     // List and sort

--- a/src/main/webapp/admin/adminbackupdownload.jsp
+++ b/src/main/webapp/admin/adminbackupdownload.jsp
@@ -99,7 +99,7 @@
                 bodd = bodd ? false : true;
                 if (contents[i].isDirectory() || contents[i].getName().equals("BackupClient.class") || contents[i].getName().startsWith("."))
                     continue;
-                out.println("<tr><td><a href="<%= request.getContextPath() %>/servlet/BackupDownload?filename=" + URLEncoder.encode(contents[i].getName()) + "'>" + contents[i].getName() + "</a></td>");
+                out.println("<tr><td><a href='" + request.getContextPath() + "/servlet/BackupDownload?filename=" + URLEncoder.encode(contents[i].getName()) + "'>" + contents[i].getName() + "</a></td>");
                 long bytes = contents[i].length();
                 String display = FileUtils.byteCountToDisplaySize(bytes);
 

--- a/src/main/webapp/admin/adminbackupdownload.jsp
+++ b/src/main/webapp/admin/adminbackupdownload.jsp
@@ -27,13 +27,15 @@
 
 <%@ page contentType="text/html; charset=UTF-8" errorPage="/errorpage.jsp" %>
 <%@ page import="
-    java.io.File,
-    java.net.URLEncoder,
-    java.util.Arrays,
-    oscar.util.FileSortByDate,
-    oscar.util.OscarProperties,
-    org.apache.commons.io.FileUtils
-" %>
+    java.util.*,
+    oscar.*,
+    java.io.*,
+    java.net.*,
+    oscar.util.*,
+    org.apache.commons.io.FileUtils"
+    errorPage="/errorpage.jsp" 
+%>
+
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 

--- a/src/main/webapp/admin/adminbackupdownload.jsp
+++ b/src/main/webapp/admin/adminbackupdownload.jsp
@@ -25,7 +25,7 @@
 
 --%>
 
-<%@ page contentType="text/html; charset=UTF-8" errorPage="/errorpage.jsp" %>
+<%@ page contentType="text/html; charset=UTF-8"%>
 <%@ page import="
     java.util.*,
     oscar.*,

--- a/src/main/webapp/documentManager/MultiPageDocDisplay.jsp
+++ b/src/main/webapp/documentManager/MultiPageDocDisplay.jsp
@@ -118,7 +118,7 @@
     <script type="text/javascript" src="<%= request.getContextPath() %>/share/calendar/calendar.js"></script>
     <!-- language for the calendar -->
     <script type="text/javascript"
-            src="<%= request.getContextPath() %>/share/calendar/lang/<fmt:setBundle basename="oscarResources'/><fmt:message key='global.javascript.calendar'/>"></script>
+            src="<%= request.getContextPath() %>/share/calendar/lang/<fmt:message key='global.javascript.calendar'/>"></script>
     <!-- the following script defines the Calendar.setup helper function, which makes
            adding a calendar a matter of 1 or 2 lines of code. -->
     <script type="text/javascript" src="<%= request.getContextPath() %>/share/calendar/calendar-setup.js"></script>

--- a/src/main/webapp/oscarRx/ChooseAllergy2.jsp
+++ b/src/main/webapp/oscarRx/ChooseAllergy2.jsp
@@ -266,7 +266,7 @@
                                                             <c:if test="${not empty allergyResults[type]}">
                                                                 <div class="DivContentSectionHead">
                                                                     <a href="javascript:void(0)" onclick="toggleSection('${type}');return false;">
-                                                                        <img border="0" id="${type}_img" src="<%= request.getContextPath() %>/images/${type == 8 || type == 10 || type == 13 || type == 14 ? "collapser' : 'expander'}.png"/>
+                                                                        <img border="0" id="${type}_img" src="<%= request.getContextPath() %>/images/${type == 8 || type == 10 || type == 13 || type == 14 ? 'collapser' : 'expander'}.png"/>
                                                                     </a>
                                                                         ${type == 8 ? 'ATC Class' : type == 10 ? 'AHFS Class' : type == 13 ? 'Brand Name' : type == 11 ? 'Generic Name' : type == 12 ? 'Compound' : 'Ingredient'}
                                                                 </div>


### PR DESCRIPTION
## Summary by Sourcery

Resolve JSP syntax errors in multiple pages and enhance the admin backup download page with null-safe session handling, JSTL tag usage, and XSS-safe file listing

Bug Fixes:
- Fix malformed expression quoting in ChooseAllergy2.jsp image source and MultiPageDocDisplay.jsp calendar script tag
- Correct missing newline at end of HTML file in ChooseAllergy2.jsp

Enhancements:
- Add null-safe session checks and redirect to login in adminbackupdownload.jsp
- Switch to JSTL taglibs for internationalization and URL generation in adminbackupdownload.jsp
- Escape file names to prevent XSS and improve error handling for missing or empty backup path