### PR TITLE
Potential fix for code scanning alert no. 286: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/oscar/form/graphic/FrmPdfGraphicRourke.java
+++ b/src/main/java/oscar/form/graphic/FrmPdfGraphicRourke.java
@@ -166,7 +166,7 @@ public class FrmPdfGraphicRourke extends FrmPdfGraphic {
                 
             case Calendar.MONTH:
             	smonth += startDate.get(Calendar.YEAR) * 12.0;
-                emonth += curDate.get(Calendar.YEAR) * 12.0;
+                emonth += (float) (curDate.get(Calendar.YEAR) * 12.0);
                 break;
                 
             default:


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/286](https://github.com/cc-ar-emr/Open-O/security/code-scanning/286)

To fix the issue, we need to ensure that the type of the left-hand side (`emonth`) is at least as wide as the type of the right-hand side (`curDate.get(Calendar.YEAR) * 12.0`). Since `emonth` is declared as a `float`, we can cast the result of the multiplication to `float` explicitly. This makes the narrowing conversion explicit and avoids relying on implicit behavior.

The specific change involves modifying the expression `emonth += curDate.get(Calendar.YEAR) * 12.0` to `emonth += (float) (curDate.get(Calendar.YEAR) * 12.0)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
