### PR TITLE
Potential fix for code scanning alert no. 506: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -330,6 +330,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
 
   public int getA1CP1()
   {
+    if (A1C < 0 || A1C > 100) {
+      throw new IllegalArgumentException("Invalid A1C value: " + A1C + ". Must be between 0 and 100.");
+    }
     return (int) A1C;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/506](https://github.com/cc-ar-emr/Open-O/security/code-scanning/506)

To fix the issue, we need to validate the `A1C` value before performing the cast to `int` in the `getA1CP1` method. Specifically:
1. Ensure that the `A1C` value is within a valid range (e.g., 0 to 100 for percentages).
2. If the value is invalid, throw an exception or handle the error appropriately.
3. Modify the `getA1CP1` method to include this validation logic.

This fix will prevent unintended truncation and ensure that the application handles invalid input gracefully.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
