### PR TITLE
Potential fix for code scanning alert no. 516: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocsAction.java
+++ b/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocsAction.java
@@ -193,6 +193,9 @@ public class ConsultationAttachDocsAction extends DispatchAction {
         //      to eforms and ticklers
 
         String segmentID = request.getParameter("segmentID");
+        if (segmentID == null || !segmentID.matches("^[a-zA-Z0-9]+$")) {
+            throw new IllegalArgumentException("Invalid segmentID");
+        }
         request.setAttribute("segmentID", segmentID);
         try {
             File tempLabPDF = File.createTempFile("lab" + segmentID, "pdf");


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/516](https://github.com/cc-ar-emr/Open-O/security/code-scanning/516)

To fix the issue, we need to validate and sanitize the `segmentID` parameter before using it to construct the file name. The validation should ensure that the `segmentID` does not contain any path traversal sequences (`..`), path separators (`/` or `\`), or other invalid characters. A simple approach is to allow only alphanumeric characters in the `segmentID`.

Additionally, we should use a secure method to construct the file name, ensuring that it is safe and predictable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
