### PR TITLE
Potential fix for code scanning alert no. 515: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocsAction.java
+++ b/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/ConsultationAttachDocsAction.java
@@ -193,6 +193,9 @@ public class ConsultationAttachDocsAction extends DispatchAction {
         //      to eforms and ticklers
 
         String segmentID = request.getParameter("segmentID");
+        if (segmentID == null || !segmentID.matches("^[a-zA-Z0-9_-]+$")) {
+            throw new IllegalArgumentException("Invalid segmentID");
+        }
         request.setAttribute("segmentID", segmentID);
         try {
             File tempLabPDF = File.createTempFile("lab" + segmentID, "pdf");


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/515](https://github.com/cc-ar-emr/Open-O/security/code-scanning/515)

To fix the issue, we need to validate the `segmentID` parameter before using it to construct the file name prefix. The validation should ensure that the `segmentID` does not contain any path traversal sequences (`../`) or invalid characters (e.g., `/`, `\`, or `:`). A simple approach is to use a regular expression to allow only alphanumeric characters and a limited set of safe characters (e.g., underscores or hyphens). If the validation fails, an exception should be thrown or an error response should be returned.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
