### PR TITLE
Potential fix for code scanning alert no. 75: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/PMmodule/GenericIntake/EditIntake.jsp
+++ b/src/main/webapp/PMmodule/GenericIntake/EditIntake.jsp
@@ -155,7 +155,7 @@
         if (lis != null){ %>
         <script>
 			function change_form(value) {
-				location.href='EditIntake.jsp?id=' + value;
+				location.href='EditIntake.jsp?id=' + encodeURIComponent(value);
 			}
         </script>
 	<select onchange="change_form(this.options[this.selectedIndex].value)">


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/75](https://github.com/cc-ar-emr/Open-O/security/code-scanning/75)

To fix the issue, the `value` variable should be sanitized or encoded before being concatenated into the URL string. This ensures that any potentially malicious characters are neutralized and cannot be interpreted as executable code. A simple and effective way to achieve this is to use `encodeURIComponent`, which encodes special characters in the `value` string, making it safe for inclusion in a URL.

The fix involves modifying the `change_form` function on line 157 to apply `encodeURIComponent` to the `value` before concatenating it into the URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
