### PR TITLE
Potential fix for code scanning alert no. 81: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
+++ b/src/main/webapp/billing/CA/ON/viewMOHFiles.jsp
@@ -84,7 +84,7 @@ function checkForm() {
 <%}%>
 
 		View: 
-		<select name="folder" onchange="location.href='viewMOHFiles.jsp?folder='+this.options[selectedIndex].value">
+		<select name="folder" onchange="location.href='viewMOHFiles.jsp?folder='+encodeURIComponent(this.options[selectedIndex].value)">
 			<option value="inbox" <% if (folder == EDTFolder.INBOX) {%>selected<%}%>>Inbox</option>
 			<option value="outbox" <% if (folder == EDTFolder.OUTBOX) {%>selected<%}%>>Outbox</option>
 			<option value="sent" <% if (folder == EDTFolder.SENT) {%>selected<%}%>>Sent</option>


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/81](https://github.com/cc-ar-emr/Open-O/security/code-scanning/81)

To fix the issue, the value of `this.options[selectedIndex].value` should be properly encoded before being used in the URL. This can be achieved by using `encodeURIComponent`, which ensures that any special characters in the value are safely escaped. This prevents the value from being interpreted as HTML or JavaScript, mitigating the risk of XSS.

The specific change involves wrapping `this.options[selectedIndex].value` with `encodeURIComponent` in the JavaScript code on line 87.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent potential cross-site scripting (XSS) attack by using encodeURIComponent on the selected folder value