### PR TITLE
Revise local repo

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
-      - "8000:8000"
+      - "18000:8000"
     volumes:
       - m2-volume:/root/.m2
       - ..:/workspace:cached 

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,6 @@
             <url>file://${basedir}/local_repo</url>
         </repository>
 
-        <repository>
-            <id>hapi-sf</id>
-            <name>HAPI Sourceforge Repository</name>
-            <url>https://hl7api.sourceforge.net/m2</url>
-        </repository>
-
         <!-- for the com.github.openosp htmltopdf dependency only. Upgrades
         from this dependency are welcome -->
         <repository>


### PR DESCRIPTION
Remove regression in pom so deprecated hl7api repo not referenced by maven; change local port forward of port 8000 to be 18000 on developer machine for devcontainer.

## Summary by Sourcery

Clean up Maven repository configuration and update local development port mapping for the devcontainer.

Enhancements:
- Remove deprecated hl7api repository reference from Maven configuration.

Build:
- Update devcontainer port forwarding to map local port 18000 to container port 8000.