### PR TITLE
Potential fix for code scanning alert no. 894: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/oscar/oscarDemographic/pageUtil/Util.java
+++ b/src/main/java/oscar/oscarDemographic/pageUtil/Util.java
@@ -427,6 +427,11 @@ public class Util {
                 File f = files.get(x);
                 if (f == null) continue;
 
+                // Validate the file path
+                if (!isPathWithinDirectory(f, dirName)) {
+                    logger.error("Error! File path is outside the allowed directory: " + f.getAbsolutePath());
+                    return false;
+                }
 
                 FileInputStream fin = new FileInputStream(f.getAbsolutePath());
 
@@ -459,6 +464,12 @@ public class Util {
             logger.error("Error", ex);
         }
         return false;
+    }
+
+    private static boolean isPathWithinDirectory(File file, String dirName) throws IOException {
+        File dir = new File(dirName).getCanonicalFile();
+        File canonicalFile = file.getCanonicalFile();
+        return canonicalFile.toPath().startsWith(dir.toPath());
     }
 
     static public void putPartialDate(cdsDt.DateFullOrPartial dfp, CaseManagementNoteExt cme) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/894](https://github.com/cc-ar-emr/Open-O/security/code-scanning/894)

To address the issue, we need to validate and sanitize the file paths before they are used in the `zipFiles` method. Specifically:
1. Ensure that the file paths are within a designated safe directory (`tmpDir`) by resolving and normalizing the paths.
2. Reject any file paths that attempt to escape the safe directory using constructs like `..` or absolute paths.
3. Update the `zipFiles` method to perform these validations before processing the files.

The changes will involve:
- Adding a helper method to validate file paths.
- Modifying the `zipFiles` method to use this helper method before accessing the files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate and sanitize file paths in zipFiles to prevent directory traversal and untrusted paths.

Bug Fixes:
- Reject file paths outside the designated safe directory in zipFiles

Enhancements:
- Introduce isPathWithinDirectory helper to normalize and verify file paths