### PR TITLE
Potential fix for code scanning alert no. 987: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
@@ -45,6 +45,8 @@ import oscar.oscarEncounter.oscarMeasurements.data.MeasurementTypes;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.ServletActionContext;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 public class EctAddMeasurementType2Action extends ActionSupport {
     HttpServletRequest request = ServletActionContext.getRequest();
     HttpServletResponse response = ServletActionContext.getResponse();
@@ -133,7 +135,7 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
 
-        errorField = "The measuring instruction " + measuringInstrc;
+        errorField = "The measuring instruction " + escapeOgnl(measuringInstrc);
         if (!validate.matchRegExp(regExp, measuringInstrc)) {
             addActionError(getText("errors.invalid", errorField));
             isValid = false;
@@ -143,6 +145,10 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
         return isValid;
+    }
+
+    private String escapeOgnl(String input) {
+        return StringEscapeUtils.escapeOgnl(input);
     }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/987](https://github.com/cc-ar-emr/Open-O/security/code-scanning/987)

To fix the issue, we need to ensure that user-controlled input (`measuringInstrc`) is sanitized or escaped before being used in any context where OGNL expressions might be evaluated. The best approach is to escape the input to neutralize any potentially malicious OGNL syntax. Additionally, we should validate the input rigorously to ensure it conforms to expected patterns.

Steps to fix:
1. Escape `measuringInstrc` before concatenating it into `errorField`.
2. Use a utility method to perform OGNL-safe escaping (e.g., Apache Commons Text's `StringEscapeUtils.escapeOgnl`).
3. Ensure that the `EctValidation` class performs robust validation to reject malicious input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
