### PR TITLE
Potential fix for code scanning alert no. 661: Code injection

### DIFF
--- a/src/main/webapp/dojoAjax/src/hostenv_browser.js
+++ b/src/main/webapp/dojoAjax/src/hostenv_browser.js
@@ -26,8 +26,9 @@ if (typeof window != 'undefined') {
                     if ((sp[0].length > 9) && (sp[0].substr(0, 9) == "djConfig.")) {
                         var opt = sp[0].substr(9);
                         try {
-                            djConfig[opt] = eval(sp[1]);
+                            djConfig[opt] = JSON.parse(sp[1]);
                         } catch (e) {
+                            // If parsing fails, treat the value as a plain string
                             djConfig[opt] = sp[1];
                         }
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/661](https://github.com/cc-ar-emr/Open-O/security/code-scanning/661)

To fix the issue, we need to eliminate the use of `eval` and replace it with a safer alternative. Specifically:
1. Parse the value of `sp[1]` as JSON if it is expected to be a JSON string. This ensures that only valid JSON data is processed.
2. If the value is not JSON, treat it as a plain string and assign it directly to `djConfig[opt]` without evaluation.
3. Update the code on line 29 to use `JSON.parse` instead of `eval`, and handle any parsing errors gracefully.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
