### PR TITLE
Potential fix for code scanning alert no. 757: Double escaping or unescaping

### DIFF
--- a/src/main/webapp/share/javascript/prototype.js
+++ b/src/main/webapp/share/javascript/prototype.js
@@ -414,7 +414,7 @@ if (Prototype.Browser.WebKit || Prototype.Browser.IE) Object.extend(String.proto
         return this.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     },
     unescapeHTML: function () {
-        return this.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+        return this.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/757](https://github.com/cc-ar-emr/Open-O/security/code-scanning/757)

To fix the issue, the `unescapeHTML` function should be modified to ensure that `&amp;` is unescaped last. This can be achieved by reordering the replacement operations so that `&lt;` and `&gt;` are processed first, followed by `&amp;`. This ensures that any `&` characters introduced during the unescaping process are not incorrectly processed as part of other entities.

The changes will be made to the `unescapeHTML` function on line 417. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
