### PR TITLE
Potential fix for code scanning alert no. 1026: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -1146,6 +1146,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
     }
 
     public int getWaistP1() {
+        if (Waist < Integer.MIN_VALUE || Waist > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Waist value is out of range for an int: " + Waist);
+        }
         return (int) Waist;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1026](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1026)

To fix the issue, we need to validate the `Waist` value before performing the cast to ensure it is within the acceptable range for an `int`. This can be done by adding a guard in the `getWaistP1` method to check that the `Waist` value is within the range of `Integer.MIN_VALUE` and `Integer.MAX_VALUE`. If the value is out of range, an exception should be thrown or an appropriate fallback value should be used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
