### PR TITLE
Potential fix for code scanning alert no. 1024: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -1076,6 +1076,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
     }
 
     public int getTC_HDLP1() {
+        if (TC_HDL < Integer.MIN_VALUE || TC_HDL > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("TC_HDL value is out of range for an int: " + TC_HDL);
+        }
         return (int) TC_HDL;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1024](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1024)

To fix the issue, we need to validate the `TC_HDL` value before casting it to an `int` in the `getTC_HDLP1` method. Specifically:
1. Ensure that the `TC_HDL` value is within the valid range for an `int` (i.e., between `Integer.MIN_VALUE` and `Integer.MAX_VALUE`).
2. If the value is out of range, handle it appropriately (e.g., throw an exception or return a default value).
3. This fix should be implemented in the `getTC_HDLP1` method in `Hsfo2Visit.java`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
