### PR TITLE
Potential fix for code scanning alert no. 986: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
@@ -123,7 +123,7 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
 
-        errorField = "The display name " + typeDisplayName;
+        errorField = "The display name " + sanitizeInput(typeDisplayName);
         if (!validate.matchRegExp(regExp, typeDisplayName)) {
             addActionError(getText("errors.invalid", errorField));
             isValid = false;
@@ -143,6 +143,14 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
         return isValid;
+    }
+
+    private String sanitizeInput(String input) {
+        if (input == null) {
+            return null;
+        }
+        // Escape special characters to neutralize OGNL syntax
+        return input.replaceAll("[{}\\[\\]\"'`$]", "");
     }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/986](https://github.com/cc-ar-emr/Open-O/security/code-scanning/986)

To fix the issue, we need to ensure that user-controlled input (`typeDisplayName`) is properly sanitized before being used in `addActionError()`. This can be achieved by:
1. Validating `typeDisplayName` against a strict whitelist of allowed characters to ensure it cannot contain malicious OGNL expressions.
2. Escaping any special characters in `typeDisplayName` to neutralize potential OGNL syntax.

The `allInputIsValid()` method should be updated to include a sanitization step for `typeDisplayName` before it is used to construct `errorField`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
