### PR TITLE
Potential fix for code scanning alert no. 1020: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -327,6 +327,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
     }
 
     public int getA1CP1() {
+        if (A1C < 0.0 || A1C > 100.0) {
+            throw new IllegalArgumentException("Invalid A1C value: " + A1C + ". Must be between 0.0 and 100.0.");
+        }
         return (int) A1C;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1020](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1020)

To fix the issue, we need to validate the `A1C` value before performing the cast to an `int` in the `getA1CP1` method. Specifically:
1. Ensure that the `A1C` value is within a valid range (e.g., 0.0 to 100.0 for percentages) before casting.
2. If the value is outside the valid range, handle it appropriately (e.g., throw an exception or return a default value).
3. Update the `getA1CP1` method to include this validation logic.

This fix ensures that the cast operation is safe and prevents unintended truncation or data corruption.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
