### PR TITLE
Potential fix for code scanning alert no. 1022: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
+++ b/src/main/java/org/oscarehr/common/model/Hsfo2Visit.java
@@ -698,6 +698,9 @@ public class Hsfo2Visit extends AbstractModel<Integer> implements Serializable {
     }
 
     public int getTriglyceridesP1() {
+        if (Triglycerides < Integer.MIN_VALUE || Triglycerides > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Triglycerides value is out of range for an int: " + Triglycerides);
+        }
         return (int) Triglycerides;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1022](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1022)

To fix the issue, we need to validate the `Triglycerides` value before performing the narrowing cast in the `getTriglyceridesP1` method. Specifically:
1. Ensure that the `Triglycerides` value is within the valid range for an `int` before casting.
2. If the value is out of range, handle it appropriately (e.g., throw an exception or return a default value).

The fix involves modifying the `getTriglyceridesP1` method in `Hsfo2Visit.java` to include a guard that checks the range of `Triglycerides` before casting. This ensures that the cast is safe and prevents truncation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
