### PR TITLE
Potential fix for code scanning alert no. 985: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/pageUtil/EctAddMeasurementType2Action.java
@@ -113,7 +113,7 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
 
-        errorField = "The type description " + typeDesc;
+        errorField = "The type description " + escapeInput(typeDesc);
         if (!validate.matchRegExp(regExp, typeDesc)) {
             addActionError(getText("errors.invalid", errorField));
             isValid = false;
@@ -143,6 +143,11 @@ public class EctAddMeasurementType2Action extends ActionSupport {
             isValid = false;
         }
         return isValid;
+    }
+
+    private String escapeInput(String input) {
+        // Escape special characters to prevent OGNL injection
+        return org.apache.commons.text.StringEscapeUtils.escapeHtml4(input);
     }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/985](https://github.com/cc-ar-emr/Open-O/security/code-scanning/985)

To fix the issue, we need to ensure that user-controlled input (`typeDesc`) is properly sanitized or validated before being used in any context where it might be evaluated as an OGNL expression. The best approach is to escape the user input to neutralize any potentially malicious OGNL syntax. Additionally, we should ensure that the `addActionError` method does not evaluate OGNL expressions.

1. Use a utility method to escape special characters in the `typeDesc` value before constructing the `errorField` string.
2. Ensure that the `EctValidation` class performs robust validation to reject any input containing unexpected characters or patterns.
3. If possible, review the implementation of `addActionError` to confirm that it does not evaluate OGNL expressions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
