### PR TITLE
Docs/updated readme with updated directory name and possible fix for docker desktop issue

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -39,7 +39,7 @@ and VS-Code.
 1. **Clone the repository:**
    ```bash
    git clone https://github.com/cc-ar-emr/Open-O.git
-   cd open-osp
+   cd Open-O
    ```
 
 2. **Confirm port availability:**
@@ -53,6 +53,7 @@ and VS-Code.
     ```
     * VS Code should automatically detect the `.devcontainer` folder and prompt you to "Reopen in Container".
     * Click "Reopen in Container" to start the development environment.
+    * *Note - Log out of any Docker Desktop account that is currently signed in*
     * *Note - In case "Reopen in Container" option does not work then:*
         * Look on bottom left of VSCode you will find a remote connection icon (green colored). Click on it.
         * It will prompt few option, select "Reopen in Container".


### PR DESCRIPTION
The README was updated to change some outdated information and potential solutions to issues with docker, this includes:
- Directory name change from "open-osp" to "Open-O"
- Note to log out of any docker desktop account when trying to open the .devcontainer folder

This will close #187 when merged