### PR TITLE
Potential fix for code scanning alert no. 568: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/PMmodule/reports/UcfReportForm.jsp
+++ b/src/main/webapp/PMmodule/reports/UcfReportForm.jsp
@@ -44,7 +44,7 @@
         if (formId != "") {
             alert("formid = " + formId);
             //alert('<%=request.getContextPath() %>/SurveyManager.do?method=export_csv&id=' + formId);
-            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=getUcfReport&forId=' + formId;
+            location.href = '<%=request.getContextPath() %>/SurveyManager.do?method=getUcfReport&forId=' + encodeURIComponent(formId);
             return true;
         } else {
             alert("Please select a form from the form list.");


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/568](https://github.com/cc-ar-emr/Open-O/security/code-scanning/568)

To fix the issue, the `formId` value should be validated or sanitized before being used in the URL string. A simple and effective approach is to encode the `formId` value to ensure that any special characters are escaped, preventing them from being interpreted as part of the HTML or JavaScript. The `encodeURIComponent` function in JavaScript is well-suited for this purpose, as it encodes a URI component by replacing special characters with their percent-encoded equivalents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
