### PR TITLE
Potential fix for code scanning alert no. 575: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/demographic/demographicappthistory.jsp
+++ b/src/main/webapp/demographic/demographicappthistory.jsp
@@ -174,7 +174,7 @@
                         ids += sels[x].value;
                     }
                 }
-                location.href = ctx + "/eyeform/Eyeform.do?method=print&apptNos=" + ids + "&cpp=" + cpp;
+                location.href = ctx + "/eyeform/Eyeform.do?method=print&apptNos=" + encodeURIComponent(ids) + "&cpp=" + encodeURIComponent(cpp);
             }
 
             function selectAllCheckboxes() {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/575](https://github.com/cc-ar-emr/Open-O/security/code-scanning/575)

To fix the issue, we need to ensure that the `sels[x].value` is properly sanitized or encoded before being used in the URL. A safe approach is to use `encodeURIComponent` to encode the `ids` string, which ensures that any special characters in the values are safely escaped and cannot be interpreted as executable code. This change will preserve the functionality of the URL while mitigating the XSS risk.

The fix involves modifying the construction of the `location.href` URL on line 177 to apply `encodeURIComponent` to the `ids` variable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
