### PR TITLE
Potential fix for code scanning alert no. 579: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eform/efmpatientformlist.jsp
+++ b/src/main/webapp/eform/efmpatientformlist.jsp
@@ -153,17 +153,17 @@
                     if (prevPage < 1) {
                         return false;
                     }
-                    location.href = '<%=reloadUrl%>' + '&page=' + prevPage + '&pageSize=' + $("#pageSize").val();
+                    location.href = encodeURIComponent('<%=reloadUrl%>') + '&page=' + encodeURIComponent(prevPage) + '&pageSize=' + encodeURIComponent($("#pageSize").val());
                 });
 
                 $("#next").bind('click', function (event) {
                     var page = $("#pageEl").val();
                     var nextPage = parseInt(page) + 1;
-                    location.href = '<%=reloadUrl%>' + '&page=' + nextPage + '&pageSize=' + $("#pageSize").val();
+                    location.href = encodeURIComponent('<%=reloadUrl%>') + '&page=' + encodeURIComponent(nextPage) + '&pageSize=' + encodeURIComponent($("#pageSize").val());
                 });
 
                 $("#pageSize").bind('change', function (event) {
-                    location.href = '<%=reloadUrl%>' + '&page=1&pageSize=' + $("#pageSize").val();
+                    location.href = encodeURIComponent('<%=reloadUrl%>') + '&page=1&pageSize=' + encodeURIComponent($("#pageSize").val());
                 });
 
             });


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/579](https://github.com/cc-ar-emr/Open-O/security/code-scanning/579)

To fix the issue, we need to ensure that any data inserted into the URL is properly sanitized or escaped to prevent XSS. Specifically:
1. Use `encodeURIComponent` to escape the values of `reloadUrl` and `$("#pageSize").val()` before concatenating them into the URL.
2. Ensure that `reloadUrl` is a trusted, sanitized server-side variable.
3. Validate the value of `$("#pageSize").val()` to ensure it only contains expected data (e.g., numeric values).

The changes will be made in the JavaScript code where the URL is constructed (lines 156, 162, and 166). We will wrap the dynamic parts of the URL in `encodeURIComponent` to ensure they are safely encoded.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
