### PR TITLE
Potential fix for code scanning alert no. 580: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eform/efmpatientformlist.jsp
+++ b/src/main/webapp/eform/efmpatientformlist.jsp
@@ -153,13 +153,13 @@
                     if (prevPage < 1) {
                         return false;
                     }
-                    location.href = '<%=reloadUrl%>' + '&page=' + prevPage + '&pageSize=' + $("#pageSize").val();
+                    location.href = encodeURIComponent('<%=reloadUrl%>') + '&page=' + prevPage + '&pageSize=' + encodeURIComponent($("#pageSize").val());
                 });
 
                 $("#next").bind('click', function (event) {
                     var page = $("#pageEl").val();
                     var nextPage = parseInt(page) + 1;
-                    location.href = '<%=reloadUrl%>' + '&page=' + nextPage + '&pageSize=' + $("#pageSize").val();
+                    location.href = encodeURIComponent('<%=reloadUrl%>') + '&page=' + nextPage + '&pageSize=' + encodeURIComponent($("#pageSize").val());
                 });
 
                 $("#pageSize").bind('change', function (event) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/580](https://github.com/cc-ar-emr/Open-O/security/code-scanning/580)

To fix the issue, we need to ensure that the value of `reloadUrl` is properly escaped or encoded before being used in the dynamically constructed URL. This can be achieved by using `encodeURIComponent` to encode the value of `reloadUrl` and any other dynamic components of the URL. This ensures that special characters are safely escaped, preventing them from being interpreted as HTML or JavaScript.

The fix involves:
1. Wrapping `<%=reloadUrl%>` in `encodeURIComponent` to escape any potentially unsafe characters.
2. Ensuring that all dynamic parts of the URL are properly encoded.

The changes will be made directly in the JavaScript code where the URL is constructed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
