### PR TITLE
Potential fix for code scanning alert no. 583: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eyeform/conreportprint.jsp
+++ b/src/main/webapp/eyeform/conreportprint.jsp
@@ -162,7 +162,7 @@
             }
 
             function phoneNumSelect() {
-                document.getElementById("clinicPhone").innerHTML = "Tel: " + document.getElementById("sendersPhone").value;
+                document.getElementById("clinicPhone").textContent = "Tel: " + document.getElementById("sendersPhone").value;
             }
 
             function faxNumSelect() {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/583](https://github.com/cc-ar-emr/Open-O/security/code-scanning/583)

To fix the issue, the value retrieved from `document.getElementById("sendersPhone").value` should be properly escaped before being assigned to the `innerHTML` property. This ensures that any special characters in the input are treated as plain text rather than HTML. The best way to achieve this is by using `textContent` instead of `innerHTML`, as `textContent` does not interpret its input as HTML. This change will preserve the intended functionality while eliminating the XSS risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
