### PR TITLE
Potential fix for code scanning alert no. 616: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/mcedt/mailbox/sent.jsp
+++ b/src/main/webapp/mcedt/mailbox/sent.jsp
@@ -140,7 +140,7 @@
                 control.disabled = true;
             }
             var temp = jQuery("#serviceId").val();
-            window.location.href = "resourceInfo.do?resourceId=" + resourceId + "&serviceId=" + jQuery("#serviceId").val();
+            window.location.href = "resourceInfo.do?resourceId=" + resourceId + "&serviceId=" + encodeURIComponent(jQuery("#serviceId").val());
             return false;
 
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/616](https://github.com/cc-ar-emr/Open-O/security/code-scanning/616)

To fix the issue, the input from `jQuery("#serviceId").val()` should be sanitized or encoded before being used in the URL. This can be achieved by using a library like `encodeURIComponent` to encode the value, ensuring that any special characters are properly escaped and cannot be interpreted as part of the URL or as executable code.

**Steps to fix:**
1. Replace the direct concatenation of `jQuery("#serviceId").val()` with a call to `encodeURIComponent(jQuery("#serviceId").val())`.
2. Ensure that all dynamic inputs used in constructing URLs are similarly sanitized or encoded.

**Changes to make:**
- Modify line 143 to use `encodeURIComponent` for the value of `#serviceId`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
