### PR TITLE
Potential fix for code scanning alert no. 617: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/mcedt/mailbox/sent.jsp
+++ b/src/main/webapp/mcedt/mailbox/sent.jsp
@@ -150,7 +150,7 @@
                 control.disabled = true;
             }
 
-            window.location.href = "reSubmit.do?resourceId=" + resourceId + "&serviceId=" + jQuery("#serviceId").val();
+            window.location.href = "reSubmit.do?resourceId=" + encodeURIComponent(resourceId) + "&serviceId=" + encodeURIComponent(jQuery("#serviceId").val());
             return false;
 
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/617](https://github.com/cc-ar-emr/Open-O/security/code-scanning/617)

To fix the issue, the value retrieved from `jQuery("#serviceId").val()` should be sanitized or encoded before being used in the URL. This ensures that any potentially malicious characters are neutralized, preventing XSS or other vulnerabilities. A common approach is to use `encodeURIComponent` to encode the value, making it safe for inclusion in a URL.

**Steps to fix:**
1. Replace the direct concatenation of `jQuery("#serviceId").val()` with a call to `encodeURIComponent(jQuery("#serviceId").val())`.
2. Ensure that the `resourceId` parameter is also sanitized or validated if it is not already safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
