### PR TITLE
Potential fix for code scanning alert no. 623: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxQuickList.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxQuickList.jsp
@@ -84,10 +84,10 @@ Required Parameters to plug-in:
 <script type="text/javascript">
     function changeList(quickList, demographicNo, providerNo) {
         location.href = 'setupDxResearch.do?demographicNo='
-            + demographicNo
+            + encodeURIComponent(demographicNo)
             + '&quickList='
-            + quickList.value
+            + encodeURIComponent(quickList.value)
             + '&providerNo='
-            + providerNo;
+            + encodeURIComponent(providerNo);
     }
 </script>


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/623](https://github.com/cc-ar-emr/Open-O/security/code-scanning/623)

To fix the issue, we need to ensure that `quickList.value` is properly encoded before being concatenated into the URL string. This can be achieved by using JavaScript's `encodeURIComponent` function, which safely encodes special characters in the value, preventing it from being interpreted as executable code or breaking the URL structure.

The fix involves modifying the `changeList` function to apply `encodeURIComponent` to `quickList.value`, `demographicNo`, and `providerNo` before concatenating them into the URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
