### PR TITLE
Potential fix for code scanning alert no. 629: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/schedule/scheduletemplatesetting1.jsp
+++ b/src/main/webapp/schedule/scheduletemplatesetting1.jsp
@@ -60,7 +60,8 @@
         function selectrschedule(s) {
             if (self.location.href.lastIndexOf("&sdate=") > 0) a = self.location.href.substring(0, self.location.href.lastIndexOf("&sdate="));
             else a = self.location.href;
-            self.location.href = a + "&sdate=" + s.options[s.selectedIndex].value;
+            var sanitizedValue = encodeURIComponent(s.options[s.selectedIndex].value);
+            self.location.href = a + "&sdate=" + sanitizedValue;
         }
 
         function upCaseCtrl(ctrl) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/629](https://github.com/cc-ar-emr/Open-O/security/code-scanning/629)

To fix the issue, the value of `s.options[s.selectedIndex].value` should be sanitized or validated before being used in the URL. This can be achieved by encoding the value to ensure that any special characters are properly escaped, preventing them from being interpreted as part of the HTML or JavaScript. The `encodeURIComponent` function in JavaScript is a suitable choice for this purpose, as it encodes a URI component by replacing special characters with their percent-encoded equivalents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
