### PR TITLE
Potential fix for code scanning alert no. 586: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/eyeform/plan_new.jsp
+++ b/src/main/webapp/eyeform/plan_new.jsp
@@ -83,7 +83,8 @@
 
         function deleteProcedure(id) {
             var procedureId = jQuery("input[name='procedure_" + id + ".id']").val();
-            jQuery("form[name='eyeformPlanForm']").append("<input type=\"hidden\" name=\"procedure.delete\" value=\"" + procedureId + "\"/>");
+            var escapedProcedureId = jQuery('<div>').text(procedureId).html();
+            jQuery("form[name='eyeformPlanForm']").append("<input type=\"hidden\" name=\"procedure.delete\" value=\"" + escapedProcedureId + "\"/>");
             jQuery("#procedure_" + id).remove();
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/586](https://github.com/cc-ar-emr/Open-O/security/code-scanning/586)

To fix the issue, we need to ensure that the `procedureId` value is properly escaped before being inserted into the DOM. This can be achieved by using a function like `jQuery('<div>').text(procedureId).html()` to escape any potentially harmful characters in `procedureId`. This approach ensures that the value is treated as plain text and not interpreted as HTML.

The changes will be made to the `deleteProcedure` function on line 86 in `src/main/webapp/eyeform/plan_new.jsp`. Specifically:
1. Escape the `procedureId` value before concatenating it into the HTML string.
2. Replace the direct concatenation with a safer approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
