### PR TITLE
Potential fix for code scanning alert no. 619: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/webapp/oscarMDS/CreateLab.jsp
+++ b/src/main/webapp/oscarMDS/CreateLab.jsp
@@ -75,7 +75,8 @@
 
         function deleteTest(id) {
             var testId = jQuery("input[name='test_" + id + ".id']").val();
-            jQuery("form[name='testForm']").append("<input type=\"hidden\" name=\"test.delete\" value=\"" + testId + "\"/>");
+            var escapedTestId = jQuery('<div>').text(testId).html(); // Escape the value
+            jQuery("form[name='testForm']").append("<input type=\"hidden\" name=\"test.delete\" value=\"" + escapedTestId + "\"/>");
             jQuery("#test_" + id).remove();
 
         }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/619](https://github.com/cc-ar-emr/Open-O/security/code-scanning/619)

To fix the issue, the value of `testId` must be properly escaped before being inserted into the HTML string. Escaping ensures that any special characters in the value are treated as plain text rather than HTML or JavaScript. The best approach is to use a library or utility function that provides robust escaping for HTML contexts. In this case, `jQuery`'s `text()` method can be used to safely insert the value into the DOM as plain text, or a utility function like `_.escape` from the `lodash` library can be used to escape the value before concatenation.

The fix involves:
1. Escaping the `testId` value before concatenating it into the HTML string.
2. Ensuring that the escaped value is safely appended to the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
