### PR TITLE
fix: inbox has repeating text

### DIFF
--- a/src/main/webapp/oscarMDS/Index.jsp
+++ b/src/main/webapp/oscarMDS/Index.jsp
@@ -555,7 +555,14 @@
                         }
                     }
 
-                    if (transport.responseText.indexOf("<input type=\"hidden\" name=\"NoMoreItems\" value=\"true\" />") >= 0) {
+                    // Parsing HTML with DOMParser, checking to see if input with the name of "NoMoreItems"
+                    // is not null, if true then set and update html to show information about "NoMoreItems"
+                    // if null, then it will fake scroll to populate the information in the list
+                    var parser = new DOMParser();
+                    var doc = parser.parseFromString(transport.responseText, "text/html");
+                    var noMoreItems = doc.querySelector("input[name='NoMoreItems']");
+
+                    if (noMoreItems) {
                         canLoad = false;
                         var div = document.getElementById("summaryBody");
                         var newDiv = "<tbody id=\"newBody\"></tbody>";


### PR DESCRIPTION
Changes:

- Parsed HTML of input "NoMoreItems" instead of parsing a string of the HTML input tag
- Changed conditional to be based on if its not null, due to this matching the new implementation of the parsing

Additional Information:

- Fixed issue with inbox repeating "NoMoreItems" html result, this was due to a space in the string HTML parsing. Used a more robust parsing method instead, added a comment explaining the conditionals

## Summary by Sourcery

Replace brittle string search for the "NoMoreItems" input with robust DOM parsing and update the conditional accordingly to prevent duplicated inbox messages.

Bug Fixes:
- Fix repeating "NoMoreItems" message by detecting the hidden input via DOMParser rather than string matching.

Enhancements:
- Add comments to explain the new HTML parsing and conditional logic.