### PR TITLE
Fixed eForm Group page's style error after adding eForm to group

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -2988,7 +2988,7 @@
   }, {
     "groupId" : "org.oscarehr.integration.ebs",
     "artifactId" : "edt-stubs",
-    "version" : "0.0.1-20140911.161211-1",
+    "version" : "0.0.1-SNAPSHOT",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
@@ -2996,7 +2996,7 @@
   }, {
     "groupId" : "org.oscarehr.integration.ebs",
     "artifactId" : "hcv-stubs",
-    "version" : "0.0.1-20140911.161502-1",
+    "version" : "0.0.1-SNAPSHOT",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,

--- a/src/main/webapp/eform/efmmanageformgroups.jsp
+++ b/src/main/webapp/eform/efmmanageformgroups.jsp
@@ -227,7 +227,7 @@
         </div>
         <!--modal-->
                 <% if (!groupView.equals("")) { %>
-        <form action="${pageContext.request.contextPath}/eform/addToGroup.do" method="get" styleId="eformToGroupForm">
+        <form action="${pageContext.request.contextPath}/eform/addToGroup.do" method="get" id="eformToGroupForm">
         <div id="myModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel"
              aria-hidden="true">
             <div class="modal-header">


### PR DESCRIPTION
Fixed error described in ticket #275

## Summary by Sourcery

Bug Fixes:
- Replace non-standard 'styleId' attribute with standard 'id' on the add-to-group form element