### PR TITLE
Fixed the schedule month view when provider set to group

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -2988,7 +2988,7 @@
   }, {
     "groupId" : "org.oscarehr.integration.ebs",
     "artifactId" : "edt-stubs",
-    "version" : "0.0.1-20140911.161211-1",
+    "version" : "0.0.1-SNAPSHOT",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
@@ -2996,7 +2996,7 @@
   }, {
     "groupId" : "org.oscarehr.integration.ebs",
     "artifactId" : "hcv-stubs",
-    "version" : "0.0.1-20140911.161502-1",
+    "version" : "0.0.1-SNAPSHOT",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,

--- a/src/main/java/org/oscarehr/common/dao/ScheduleDateDao.java
+++ b/src/main/java/org/oscarehr/common/dao/ScheduleDateDao.java
@@ -47,7 +47,7 @@ public interface ScheduleDateDao extends AbstractDao<ScheduleDate> {
 
     List<ScheduleDate> search_scheduledate_teamp(Date date, Date date2, Character status, List<String> providerNos);
 
-    List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, String status);
+    List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, Character status);
 
     List<ScheduleDate> findByProviderStartDateAndPriority(String providerNo, Date apptDate, String priority);
 }

--- a/src/main/java/org/oscarehr/common/dao/ScheduleDateDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ScheduleDateDaoImpl.java
@@ -125,7 +125,7 @@ public class ScheduleDateDaoImpl extends AbstractDaoImpl<ScheduleDate> implement
     }
 
     @Override
-    public List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, String status) {
+    public List<ScheduleDate> search_scheduledate_datep(Date date, Date date2, Character status) {
         Query query = entityManager.createQuery("select s from ScheduleDate s where s.date>=?1 and s.date <=?2 and s.status=?3  order by s.date");
         query.setParameter(1, date);
         query.setParameter(2, date2);

--- a/src/main/webapp/provider/appointmentprovideradminmonth.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminmonth.jsp
@@ -646,7 +646,7 @@
                                         param[0] = year + "-" + month + "-" + "1";
                                         param[1] = cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "1";
                                         if (selectedSite == null) {
-                                            sds = scheduleDateDao.search_scheduledate_datep(ConversionUtils.fromDateString(year + "-" + month + "-" + "01"), ConversionUtils.fromDateString(cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "01"), "A");
+                                            sds = scheduleDateDao.search_scheduledate_datep(ConversionUtils.fromDateString(year + "-" + month + "-" + "01"), ConversionUtils.fromDateString(cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "01"), 'A');
                                         } else {
                                             List<String> ps = providerSiteDao.findByProviderNoBySiteName(selectedSite);
                                             sds = scheduleDateDao.search_scheduledate_teamp(ConversionUtils.fromDateString(year + "-" + month + "-" + "01"), ConversionUtils.fromDateString(cal.get(Calendar.YEAR) + "-" + (cal.get(Calendar.MONTH) + 1) + "-" + "01"), 'A', ps);


### PR DESCRIPTION
Fixed the issue described in ticket #272 
The status attribute type had to change to Character since it was set as char property in ScheduleDate.java.
It was written as String attribute by mistake from previous development team.

## Summary by Sourcery

Bug Fixes:
- Change status parameter type to Character in ScheduleDate DAO interface, implementation, and JSP to match entity definition and resolve the month view issue.