### PR TITLE
fix: calendar button does nothing

### DIFF
--- a/src/main/webapp/provider/appointmentprovideradminday.jsp
+++ b/src/main/webapp/provider/appointmentprovideradminday.jsp
@@ -1217,9 +1217,19 @@
                     <span class="glyphicon glyphicon-step-forward"
                           title="<fmt:setBundle basename="oscarResources"/><fmt:message key="provider.appointmentProviderAdminDay.viewNextDay"/>"></span>
                 </a>
-                <a id="calendarLink" href=#
-                   onClick="popupPage(425,430,'../share/CalendarPopup.jsp?urlfrom=../provider/providercontrol.jsp&year=<%=strYear%>&month=<%=strMonth%>&param=<%=URLEncoder.encode("&view=0&displaymode=day&dboperation=searchappointmentday&viewall="+viewall,"UTF-8")%>
-                           <%=isWeekView?URLEncoder.encode("&provider_no="+provNum, "UTF-8"):""%>')"><fmt:setBundle basename="oscarResources"/><fmt:message key="global.calendar"/></a>
+
+                <%
+                    String calendarUrl = "../share/CalendarPopup.jsp?urlfrom=../provider/providercontrol.jsp" + "&year=" + strYear + "&month=" + strMonth + "&param=" + URLEncoder.encode("&view=0&displaymode=day&dboperation=searchappointmentday&viewall=" + viewall, "UTF-8");
+
+                    if (isWeekView) {
+                        calendarUrl += URLEncoder.encode("&provider_no=" + provNum, "UTF-8");
+                    }
+                %>
+
+                <a id="calendarLink" href="#" onClick="popupPage(425,430,'<%=calendarUrl%>')">
+                    <fmt:setBundle basename="oscarResources"/>
+                    <fmt:message key="global.calendar"/>
+                </a>
 
                 <c:if test="${infirmaryView_isOscar != 'false'}">
                     <% if (request.getParameter("viewall") != null && request.getParameter("viewall").equals("1")) { %>


### PR DESCRIPTION
Fixed calendar button not working and throwing a syntax error, reworte url in scriplet above for better readability, which fixed the issue.

## Summary by Sourcery

Fix the calendar button on the appointment provider admin day page by refactoring its popup URL construction into a server-side scriptlet.

Bug Fixes:
- Restore functionality of the calendar button by fixing the malformed URL scriptlet that caused a syntax error.

Enhancements:
- Build the calendar popup URL in a JSP scriptlet for improved readability and maintainability.