### PR TITLE
fix : disease registry has issues

### DIFF
--- a/src/main/java/oscar/oscarResearch/oscarDxResearch/pageUtil/dxResearch2Action.java
+++ b/src/main/java/oscar/oscarResearch/oscarDxResearch/pageUtil/dxResearch2Action.java
@@ -150,7 +150,7 @@ public class dxResearch2Action extends ActionSupport {
         }
 
         if (!valid) {
-            response.sendRedirect("/oscarResearch/oscarDxResearch/dxResearch.jsp");
+            response.sendRedirect(request.getContextPath() + "/oscarResearch/oscarDxResearch/dxResearch.jsp");
             return NONE;
         }
 
@@ -161,11 +161,11 @@ public class dxResearch2Action extends ActionSupport {
 
         StringBuilder actionforward = new StringBuilder();
         if ("success".equals(forwardTo)) {
-            actionforward = new StringBuilder("/oscarResearch/oscarDxResearch/setupDxResearch.do");
+            actionforward = new StringBuilder(request.getContextPath() + "/oscarResearch/oscarDxResearch/setupDxResearch.do");
         } else if ("codeSearch".equals(forwardTo)) {
-            actionforward = new StringBuilder("/oscarResearch/oscarDxResearch/dxcodeSearch.do");
+            actionforward = new StringBuilder(request.getContextPath() + "/oscarResearch/oscarDxResearch/dxcodeSearch.do");
         } else if ("codeList".equals(forwardTo)) {
-            actionforward = new StringBuilder("/oscarResearch/oscarDxResearch/quickCodeList.jsp");
+            actionforward = new StringBuilder(request.getContextPath() + "/oscarResearch/oscarDxResearch/quickCodeList.jsp");
         }
         actionforward.append("?demographicNo=").append(demographicNo);
         actionforward.append("&providerNo=").append(providerNo);

--- a/src/main/java/oscar/oscarResearch/oscarDxResearch/pageUtil/dxResearchUpdate2Action.java
+++ b/src/main/java/oscar/oscarResearch/oscarDxResearch/pageUtil/dxResearchUpdate2Action.java
@@ -90,7 +90,7 @@ public class dxResearchUpdate2Action extends ActionSupport {
             dao.merge(research);
         }
 
-        StringBuffer forward = new StringBuffer("/oscarResearch/oscarDxResearch/setupDxResearch.do");
+        StringBuffer forward = new StringBuffer(request.getContextPath() + "/oscarResearch/oscarDxResearch/setupDxResearch.do");
         forward.append("?demographicNo=").append(demographicNo);
         forward.append("&providerNo=").append(providerNo);
         forward.append("&quickList=");

--- a/src/main/webapp/oscarReport/oscarReportDxReg.jsp
+++ b/src/main/webapp/oscarReport/oscarReportDxReg.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="/WEB-INF/security.tld" prefix="security" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%
     String roleName$ = (String) session.getAttribute("userrole") + "," + (String) session.getAttribute("user");
     boolean authed = true;
@@ -166,7 +167,7 @@
                            class="span4 jsonDxSearch"/>
                 </div>
                 <div class="row-fluid">
-                    <nested:submit styleClass="btn btn-primary">Add</nested:submit>
+                    <input type="submit" class="btn btn-primary" value="Add" />
                     <input type="button" class="btn btn-danger" value="Clear"
                            onclick="javascript:this.form.action='${pageContext.servletContext.contextPath}/report/DxresearchReport.do?method=clearSearchCode';this.form.submit()"/>
                 </div>
@@ -177,7 +178,7 @@
             <strong>Search all patients with disease codes:</strong>
         </div>
 
-        <nested:form action='<%=formAction%>' styleClass="form-inline">
+        <form action='<%=formAction%>' class="form-inline">
 
             <div class="row-fluid">
                 <display:table name="codeSearch" id="codeSearch" class="table table-condensed table-striped">
@@ -255,7 +256,7 @@
                 </select>
 
 
-                <nested:submit styleClass="btn btn-primary">Search</nested:submit>
+                <input type="submit" class="btn btn-primary" value="Search" />
             </div>
 
             <h3>Results</h3>
@@ -281,7 +282,7 @@
                        onclick="javascript:this.form.action='${pageContext.servletContext.contextPath}/report/DxresearchReport.do?method=patientExcelReport';this.form.submit()">
             </c:if>
 
-        </nested:form>
+        </form>
     </div>
     </body>
 </html>

--- a/src/main/webapp/oscarReport/oscarReportDxReg.jsp
+++ b/src/main/webapp/oscarReport/oscarReportDxReg.jsp
@@ -127,9 +127,12 @@
         String mygroupno = providerPreference.getMyGroupNo();
         pageContext.setAttribute("mygroupno", mygroupno);
         String radiostatus = (String) session.getAttribute("radiovaluestatus");
-        if (radiostatus == null || radiostatus.isEmpty())
+        if (radiostatus == null || radiostatus.isEmpty()) {
             radiostatus = "patientRegistedAll";
+            session.setAttribute("radiovaluestatus", radiostatus);
+        }
         String formAction = request.getContextPath() + "/report/DxresearchReport.do?method=" + radiostatus;
+        request.setAttribute("radiostatus", radiostatus);
         request.setAttribute("listview", request.getSession().getAttribute("listview"));
         request.setAttribute("codeSearch", request.getSession().getAttribute("codeSearch"));
         //request.setAttribute("editingCode", request.getSession().getAttribute("editingCode"));
@@ -192,28 +195,28 @@
             </div>
             <div class="row-fluid">
                 <label class="radio">
-                    <input type="radio" name="SearchBy" value="radio"
-                           id="SearchBy_0" <c:if test="${radiostatus == 'patientRegistedDistincted'}">checked</c:if>
+                    <input type="radio" name="SearchBy" value="patientRegistedDistincted"
+                           id="SearchBy_Distincted" <c:if test="${radiostatus == 'patientRegistedDistincted'}">checked</c:if>
                            onclick="javascript:this.form.action='<%= request.getContextPath()%>/report/DxresearchReport.do?method=patientRegistedDistincted'">
                     ALL(distincted)</label>
                 <label class="radio">
-                    <input type="radio" name="SearchBy" value="radio"
-                           id="SearchBy_1" <c:if test="${radiostatus == 'patientRegistedAll'}">checked</c:if>
+                    <input type="radio" name="SearchBy" value="patientRegistedAll"
+                           id="SearchBy_All" <c:if test="${radiostatus == 'patientRegistedAll'}">checked</c:if>
                            onclick="javascript:this.form.action='<%= request.getContextPath()%>/report/DxresearchReport.do?method=patientRegistedAll'">
                     ALL</label>
                 <label class="radio">
-                    <input type="radio" name="SearchBy" value="radio"
-                           id="SearchBy_0" <c:if test="${radiostatus == 'patientRegistedActive'}">checked</c:if>
+                    <input type="radio" name="SearchBy" value="patientRegistedActive"
+                           id="SearchBy_Active" <c:if test="${radiostatus == 'patientRegistedActive'}">checked</c:if>
                            onclick="javascript:this.form.action='<%= request.getContextPath()%>/report/DxresearchReport.do?method=patientRegistedActive'">
                     Active</label>
                 <label class="radio">
-                    <input type="radio" name="SearchBy" value="radio"
-                           id="SearchBy_0" <c:if test="${radiostatus == 'patientRegistedDeleted'}">checked</c:if>
+                    <input type="radio" name="SearchBy" value="patientRegistedDeleted"
+                           id="SearchBy_Deleted" <c:if test="${radiostatus == 'patientRegistedDeleted'}">checked</c:if>
                            onclick="javascript:this.form.action='<%= request.getContextPath()%>/report/DxresearchReport.do?method=patientRegistedDeleted'">
                     Deleted</label>
                 <label class="radio">
-                    <input type="radio" name="SearchBy" value="radio"
-                           id="SearchBy_1" <c:if test="${radiostatus == 'patientRegistedResolve'}">checked</c:if>
+                    <input type="radio" name="SearchBy" value="patientRegistedResolve"
+                           id="SearchBy_Resolved" <c:if test="${radiostatus == 'patientRegistedResolve'}">checked</c:if>
                            onclick="javascript:this.form.action='<%= request.getContextPath()%>/report/DxresearchReport.do?method=patientRegistedResolve'">
                     Resolved</label>
 

--- a/src/main/webapp/oscarReport/oscarReportDxReg.jsp
+++ b/src/main/webapp/oscarReport/oscarReportDxReg.jsp
@@ -17,6 +17,7 @@
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 --%>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="org.oscarehr.util.SessionConstants" %>
 <%@ page import="org.oscarehr.common.model.ProviderPreference" %>
 <%@ include file="/taglibs.jsp" %>
@@ -58,6 +59,8 @@
 <html>
     <head>
         <title><fmt:setBundle basename="oscarResources"/><fmt:message key="admin.admin.DiseaseRegistry"/></title>
+
+        <meta charset="UTF-8">
 
         <link rel="stylesheet" type="text/css" media="all"
               href="${pageContext.servletContext.contextPath}/library/jquery/jquery-ui.theme-1.12.1.min.css"/>
@@ -124,9 +127,9 @@
         String mygroupno = providerPreference.getMyGroupNo();
         pageContext.setAttribute("mygroupno", mygroupno);
         String radiostatus = (String) session.getAttribute("radiovaluestatus");
-        if (radiostatus == null || radiostatus == "")
+        if (radiostatus == null || radiostatus.isEmpty())
             radiostatus = "patientRegistedAll";
-        String formAction = "/report/DxresearchReport?method=" + radiostatus;
+        String formAction = request.getContextPath() + "/report/DxresearchReport.do?method=" + radiostatus;
         request.setAttribute("listview", request.getSession().getAttribute("listview"));
         request.setAttribute("codeSearch", request.getSession().getAttribute("codeSearch"));
         //request.setAttribute("editingCode", request.getSession().getAttribute("editingCode"));
@@ -145,7 +148,7 @@
         </div>
 
         <div class="well well-small">
-            <form action="${pageContext.request.contextPath}/report/DxresearchReport?method=addSearchCode.do" method="post">
+            <form action="${pageContext.request.contextPath}/report/DxresearchReport.do?method=addSearchCode" method="post" accept-charset="UTF-8">
                 <div class="row-fluid">
                     <input type="hidden" name="action" value="NA"/>
                     <select name="quicklistname" class="sel">
@@ -178,7 +181,7 @@
             <strong>Search all patients with disease codes:</strong>
         </div>
 
-        <form action='<%=formAction%>' class="form-inline">
+        <form action="<%=formAction%>" method="post" class="form-inline" accept-charset="UTF-8">
 
             <div class="row-fluid">
                 <display:table name="codeSearch" id="codeSearch" class="table table-condensed table-striped">

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearch.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearch.jsp
@@ -48,11 +48,16 @@
     boolean disable;
     SecurityManager sm = new SecurityManager();
 
+    // Check to see if the currently logged in role has write access, if so, disable input fields present in the page
     if (sm.hasWriteAccess("_dx.code", roleName$)) {
         disable = false;
     } else {
         disable = true;
     }
+
+    // Set a String based on the "disable" boolean for easy access to use html functionality of "disabled" attribute
+    String disabled = disable ? "disabled" : "";
+
     boolean showQuicklist = false;
 
     if (sm.hasWriteAccess("_dx.quicklist", roleName$)) {
@@ -65,6 +70,7 @@
 
     pageContext.setAttribute("showQuicklist", showQuicklist);
     pageContext.setAttribute("disable", disable);
+    pageContext.setAttribute("disabled", disabled);
 %>
 
 <!DOCTYPE html>
@@ -234,7 +240,7 @@
 								</span>
 
                                                 <select class="form-control" name="selectedCodingSystem"
-                                                            <%= disable ? "disabled" : "" %>>
+                                                            <%=disabled%>>
                                                     <c:forEach var="codingSys" items="${codingSystem.codingSystems}">
                                                         <option value="${codingSys}">
                                                             <c:out value="${codingSys}"/>
@@ -246,7 +252,7 @@
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research1"
-                                                    <%= disable ? "disabled" : "" %> />
+                                                    <%=disabled%> />
                                             <input type="hidden" name="demographicNo"
                                                    value="<c:out value="${demographicNo}"/>">
                                             <input type="hidden" name="providerNo"
@@ -254,19 +260,19 @@
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research2"
-                                                       <%= disable ? "disabled" : "" %>/></td>
+                                                       <%=disabled%>/></td>
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research3"
-                                                       <%= disable ? "disabled" : "" %>/></td>
+                                                       <%=disabled%>/></td>
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research4"
-                                                       <%= disable ? "disabled" : "" %>/></td>
+                                                       <%=disabled%>/></td>
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research5"
-                                                       <%= disable ? "disabled" : "" %>/></td>
+                                                       <%=disabled%>/></td>
                                     </tr>
                                     <tr>
                                         <td>
@@ -285,11 +291,11 @@
                                             <input type="button" name="button" class="btn btn-primary"
                                                    value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarResearch.oscarDxResearch.btnCodeSearch"/>"
                                                    onClick="javascript: ResearchScriptAttach();" )
-                                                   <%= disable ? "disabled" : "" %>">
+                                                   <%=disabled%>">
 
                                             <input type="button" name="button" class="btn btn-primary"
                                                    value="<fmt:setBundle basename="oscarResources"/><fmt:message key="ADD"/>"
-                                                   onClick="javascript: submitform('','');" <%= disable ? "disabled" : "" %>">
+                                                   onClick="javascript: submitform('','');" <%=disabled%>">
                                             <% } %>
                                         </td>
                                     </tr>

--- a/src/main/webapp/oscarResearch/oscarDxResearch/dxResearch.jsp
+++ b/src/main/webapp/oscarResearch/oscarDxResearch/dxResearch.jsp
@@ -234,7 +234,7 @@
 								</span>
 
                                                 <select class="form-control" name="selectedCodingSystem"
-                                                             disabled="<%=disable%>">
+                                                            <%= disable ? "disabled" : "" %>>
                                                     <c:forEach var="codingSys" items="${codingSystem.codingSystems}">
                                                         <option value="${codingSys}">
                                                             <c:out value="${codingSys}"/>
@@ -246,7 +246,7 @@
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research1"
-                                                       disabled="<%=disable%>"/>
+                                                    <%= disable ? "disabled" : "" %> />
                                             <input type="hidden" name="demographicNo"
                                                    value="<c:out value="${demographicNo}"/>">
                                             <input type="hidden" name="providerNo"
@@ -254,19 +254,19 @@
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research2"
-                                                       disabled="<%=disable%>"/></td>
+                                                       <%= disable ? "disabled" : "" %>/></td>
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research3"
-                                                       disabled="<%=disable%>"/></td>
+                                                       <%= disable ? "disabled" : "" %>/></td>
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research4"
-                                                       disabled="<%=disable%>"/></td>
+                                                       <%= disable ? "disabled" : "" %>/></td>
                                     </tr>
                                     <tr>
                                         <td><input type="text" class="form-control" name="xml_research5"
-                                                       disabled="<%=disable%>"/></td>
+                                                       <%= disable ? "disabled" : "" %>/></td>
                                     </tr>
                                     <tr>
                                         <td>
@@ -285,11 +285,11 @@
                                             <input type="button" name="button" class="btn btn-primary"
                                                    value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarResearch.oscarDxResearch.btnCodeSearch"/>"
                                                    onClick="javascript: ResearchScriptAttach();" )
-                                                   disabled="<%=disable%>">
+                                                   <%= disable ? "disabled" : "" %>">
 
                                             <input type="button" name="button" class="btn btn-primary"
                                                    value="<fmt:setBundle basename="oscarResources"/><fmt:message key="ADD"/>"
-                                                   onClick="javascript: submitform('','');" disabled="<%=disable%>">
+                                                   onClick="javascript: submitform('','');" <%= disable ? "disabled" : "" %>">
                                             <% } %>
                                         </td>
                                     </tr>


### PR DESCRIPTION
Fixed issues in patient echart disease registry:

- Not being able to input any disease registry codes as the input fields were disabled by default
- 500 error on submission of page
- 404 errors when submitting page, or using the options on an already existing registered disease

Fixed issues in administration disease registry:

- broken form and button options that had broken styling and deprecated struts 1 nested tags
- 404 errors on buttons when submitting forms
- Replacing character set of html to UTF-8
- Setting different values and id's for radio buttons that caused radio buttons to be deselected

## Summary by Sourcery

Fix patient and administration disease registry pages by re-enabling input fields, correcting form actions and redirects, replacing deprecated tags, and standardising encoding and radio button behavior.

Bug Fixes:
- Enable disease registry input fields by setting disabled attribute based on user permissions
- Resolve 500 and 404 errors by updating form action URLs and response redirects to include the correct context path
- Replace deprecated Struts nested tags with standard HTML inputs to restore button functionality
- Correct radio button values and IDs to prevent deselection issues

Enhancements:
- Set HTML character encoding to UTF-8 in JSPs
- Introduce a JSP string variable for the disabled attribute to simplify form field handling
- Consolidate context path usage across form submissions and redirects for consistency