### PR TITLE
fix: consultation request 500 error

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
@@ -50,6 +50,18 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
     private static SecurityInfoManager securityInfoManager = SpringUtils.getBean(SecurityInfoManager.class);
     private static final Logger logger = MiscUtils.getLogger();
 
+    private String sendTo;
+    private String currentTeam;
+
+    private String startDate;
+    private String endDate;
+    private String includeCompleted;
+    private String orderby;
+    private String desc;
+    private String searchDate = null;
+    private Integer offset;
+    private Integer limit = ConsultationRequestDaoImpl.DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT;
+
     public String execute()
             throws ServletException, IOException {
 
@@ -98,24 +110,20 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
     }
 
     public String getSendTo() {
-
         return sendTo;
     }
 
     public void setSendTo(String str) {
-
         sendTo = str;
     }
 
     public String getCurrentTeam() {
-
         if (currentTeam == null)
             currentTeam = new String();
         return currentTeam;
     }
 
     public void setCurrentTeam(String str) {
-
         currentTeam = str;
     }
 
@@ -124,7 +132,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @return Value of property startDate.
      */
-    public java.lang.String getStartDate() {
+    public String getStartDate() {
         return startDate;
     }
 
@@ -133,7 +141,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @param startDate New value of property startDate.
      */
-    public void setStartDate(java.lang.String startDate) {
+    public void setStartDate(String startDate) {
         this.startDate = startDate;
     }
 
@@ -142,7 +150,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @return Value of property endDate.
      */
-    public java.lang.String getEndDate() {
+    public String getEndDate() {
         return endDate;
     }
 
@@ -151,7 +159,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @param endDate New value of property endDate.
      */
-    public void setEndDate(java.lang.String endDate) {
+    public void setEndDate(String endDate) {
         this.endDate = endDate;
     }
 
@@ -160,7 +168,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @return Value of property includeCompleted.
      */
-    public java.lang.String getIncludeCompleted() {
+    public String getIncludeCompleted() {
         return includeCompleted;
     }
 
@@ -169,7 +177,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @param includeCompleted New value of property includeCompleted.
      */
-    public void setIncludeCompleted(java.lang.String includeCompleted) {
+    public void setIncludeCompleted(String includeCompleted) {
         this.includeCompleted = includeCompleted;
     }
 
@@ -178,7 +186,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @return Value of property orderby.
      */
-    public java.lang.String getOrderby() {
+    public String getOrderby() {
         return orderby;
     }
 
@@ -187,7 +195,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @param orderby New value of property orderby.
      */
-    public void setOrderby(java.lang.String orderby) {
+    public void setOrderby(String orderby) {
         this.orderby = orderby;
     }
 
@@ -196,7 +204,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @return Value of property desc.
      */
-    public java.lang.String getDesc() {
+    public String getDesc() {
         return desc;
     }
 
@@ -205,7 +213,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @param desc New value of property desc.
      */
-    public void setDesc(java.lang.String desc) {
+    public void setDesc(String desc) {
         this.desc = desc;
     }
 
@@ -214,7 +222,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @return Value of property searchDate.
      */
-    public java.lang.String getSearchDate() {
+    public String getSearchDate() {
         if (searchDate == null) {
             searchDate = "0";
         }
@@ -226,7 +234,7 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
      *
      * @param searchDate New value of property searchDate.
      */
-    public void setSearchDate(java.lang.String searchDate) {
+    public void setSearchDate(String searchDate) {
         this.searchDate = searchDate;
     }
 
@@ -245,16 +253,4 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
     public void setLimit(Integer limit) {
         this.limit = limit;
     }
-
-    String sendTo;
-    String currentTeam;
-
-    String startDate;
-    String endDate;
-    String includeCompleted;
-    String orderby;
-    String desc;
-    String searchDate = null;
-    Integer offset;
-    Integer limit = ConsultationRequestDaoImpl.DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT;
 }

--- a/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/EctViewConsultationRequests2Action.java
@@ -62,22 +62,14 @@ public class EctViewConsultationRequests2Action extends ActionSupport {
     private Integer offset;
     private Integer limit = ConsultationRequestDaoImpl.DEFAULT_CONSULT_REQUEST_RESULTS_LIMIT;
 
-    public String execute()
-            throws ServletException, IOException {
-
+    public String execute() throws ServletException, IOException {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_con", "r", null)) {
             throw new SecurityException("missing required security object (_con)");
         }
 
         String defaultPattern = "yyyy-MM-dd";
-        //String sendTo = null;
         String includeCompleted = null;
-        //String startDate = frm.getStartDate();
-        //String endDate = frm.getEndDate();
         boolean includedComp = false;
-
-        //sendTo = frm.getSendTo();
-        //includeCompleted = frm.getIncludeCompleted();
 
         if (includeCompleted != null && includeCompleted.equals("include")) {
             includedComp = true;

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -142,7 +142,7 @@
         Boolean includeBool = (Boolean) request.getAttribute("includeCompleted");
         boolean includeCompleted = false;
         if (includeBool != null) {
-            includeCompleted = includeBool.booleanValue();
+            includeCompleted = "on".equals(request.getParameter("includeCompleted"));
         }
 
         // Getting startDate attribute of the consultation request and ensuring that it is of type "Date" before casting
@@ -363,13 +363,13 @@
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.btnConsReq"/>"/>
                                 <div style="margin: 0; padding: 0; ">
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgStart"/>:
-                                    <input type="text" name="startDate" size="8" id="startDate"/><a id="SCal"><img
+                                    <input type="text" name="startDate" size="8" id="startDate" value="<%= startDate != null ? startDate : "" %>" /><a id="SCal"><img
                                         title="Calendar" src="<%= request.getContextPath() %>/images/cal.gif" alt="Calendar" border="0"/></a>
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgEnd"/>:
-                                    <input type="text" name="endDate" size="8" id="endDate"/><a id="ECal"><img
+                                    <input type="text" name="endDate" size="8" id="endDate" value="<%= endDate != null ? endDate : "" %>" /><a id="ECal"><img
                                         title="Calendar" src="<%= request.getContextPath() %>/images/cal.gif" alt="Calendar" border="0"/></a>
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgIncludeCompleted"/>:
-                                    <input type="checkbox" name="includeCompleted" value="include"/>
+                                    <input type="checkbox" name="includeCompleted" <%= includeCompleted ? "checked" : "" %> />
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgSearchon"/>
                                     <input type="radio" name="searchDate" value="0" titleKey="Search on Referal Date"
                                         <%= "0".equals(searchDate) ? "checked" : "" %> />
@@ -379,7 +379,7 @@
                                     <input type="hidden" name="currentTeam" id="currentTeam"/>
                                     <input type="hidden" name="orderby" id="orderby"/>
                                     <input type="hidden" name="desc" id="desc"/>
-                                    <input type="hidden" name="offset" id="offset"/>
+                                    <input type="hidden" name="offset" id="offset" value="<%= offset %>"/>
                                     <input type="hidden" name="limit" id="limit" value="<%= limit %>"/>
                                 </div>
                             </form>

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -147,8 +147,21 @@
             includeCompleted = includeBool.booleanValue();
         }
 
-        Date startDate = (Date) request.getAttribute("startDate");
-        Date endDate = (Date) request.getAttribute("endDate");
+        // Getting startDate attribute of the consultation request and ensuring that it is of type "Date" before casting
+        Object startObj = request.getAttribute("startDate");
+        Date startDate = null;
+        if (startObj instanceof Date) {
+            startDate = (Date) startObj;
+        }
+    
+        // Getting endDate attribute of the consultation request and ensuring that it is of type "Date" before casting
+        Object endObj = request.getAttribute("endDate");
+        Date endDate = null;
+        if (endObj instanceof Date) {
+            endDate = (Date) endObj;
+        }
+
+        // Getting orderby, description, and searchDate attributes of the consultation request
         String orderby = (String) request.getAttribute("orderby");
         String desc = (String) request.getAttribute("desc");
         String searchDate = (String) request.getAttribute("searchDate");

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -54,10 +54,10 @@
 <%@ page import="org.oscarehr.common.model.ProviderData" %>
 <%@ page import="org.oscarehr.common.dao.ProviderDataDao" %>
 
+<%@ page import="java.text.SimpleDateFormat" %>
+
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-
-
 
 <%
     String curProvider_no = (String) session.getAttribute("user");
@@ -145,18 +145,24 @@
             includeCompleted = "on".equals(request.getParameter("includeCompleted"));
         }
 
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+
         // Getting startDate attribute of the consultation request and ensuring that it is of type "Date" before casting
-        Object startObj = request.getAttribute("startDate");
+        Object startDateObj = request.getAttribute("startDate");
         Date startDate = null;
-        if (startObj instanceof Date) {
-            startDate = (Date) startObj;
+        String formattedStartDate = "";
+        if (startDateObj instanceof Date) {
+            startDate = (Date) startDateObj;
+            formattedStartDate = sdf.format(startDateObj);
         }
     
         // Getting endDate attribute of the consultation request and ensuring that it is of type "Date" before casting
-        Object endObj = request.getAttribute("endDate");
+        Object endDateObj = request.getAttribute("endDate");
         Date endDate = null;
-        if (endObj instanceof Date) {
-            endDate = (Date) endObj;
+        String formattedEndDate = "";
+        if (endDateObj instanceof Date) {
+            endDate = (Date) endDateObj;
+            formattedEndDate = sdf.format(endDateObj);
         }
 
         // Getting orderby, description, and searchDate attributes of the consultation request
@@ -363,10 +369,10 @@
                                        value="<fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.btnConsReq"/>"/>
                                 <div style="margin: 0; padding: 0; ">
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgStart"/>:
-                                    <input type="text" name="startDate" size="8" id="startDate" value="<%= startDate != null ? startDate : "" %>" /><a id="SCal"><img
+                                    <input type="text" name="startDate" size="8" id="startDate" value="<%= formattedStartDate %>" /><a id="SCal"><img
                                         title="Calendar" src="<%= request.getContextPath() %>/images/cal.gif" alt="Calendar" border="0"/></a>
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgEnd"/>:
-                                    <input type="text" name="endDate" size="8" id="endDate" value="<%= endDate != null ? endDate : "" %>" /><a id="ECal"><img
+                                    <input type="text" name="endDate" size="8" id="endDate" value="<%= formattedEndDate %>" /><a id="ECal"><img
                                         title="Calendar" src="<%= request.getContextPath() %>/images/cal.gif" alt="Calendar" border="0"/></a>
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgIncludeCompleted"/>:
                                     <input type="checkbox" name="includeCompleted" <%= includeCompleted ? "checked" : "" %> />

--- a/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
+++ b/src/main/webapp/oscarEncounter/oscarConsultationRequest/ViewConsultationRequests.jsp
@@ -86,8 +86,6 @@
     } catch (NumberFormatException e) {
         limit = 100;
     }
-
-
 %>
 <security:oscarSec objectName="_site_access_privacy" roleName="<%=roleName$%>" rights="r"
                    reverse="false"><%isSiteAccessPrivacy = true; %></security:oscarSec>
@@ -165,6 +163,11 @@
         String orderby = (String) request.getAttribute("orderby");
         String desc = (String) request.getAttribute("desc");
         String searchDate = (String) request.getAttribute("searchDate");
+
+        // Setting defaults to match consultation request in struts 1
+        if (searchDate == null) {
+            searchDate = "0";
+        }
 
         oscar.oscarEncounter.oscarConsultationRequest.pageUtil.EctConsultationFormRequestUtil consultUtil;
         consultUtil = new oscar.oscarEncounter.oscarConsultationRequest.pageUtil.EctConsultationFormRequestUtil();
@@ -368,14 +371,16 @@
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgIncludeCompleted"/>:
                                     <input type="checkbox" name="includeCompleted" value="include"/>
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgSearchon"/>
-                                    <input type="radio" name="searchDate" value="0" titleKey="Search on Referal Date"/>
+                                    <input type="radio" name="searchDate" value="0" titleKey="Search on Referal Date"
+                                        <%= "0".equals(searchDate) ? "checked" : "" %> />
                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.oscarConsultationRequest.ViewConsultationRequests.msgApptDate"/>
-                                    <input type="radio" name="searchDate" value="1" titleKey="Search on Appt. Date"/>
+                                    <input type="radio" name="searchDate" value="1" titleKey="Search on Appt. Date"
+                                        <%= "1".equals(searchDate) ? "checked" : "" %> />
                                     <input type="hidden" name="currentTeam" id="currentTeam"/>
                                     <input type="hidden" name="orderby" id="orderby"/>
                                     <input type="hidden" name="desc" id="desc"/>
                                     <input type="hidden" name="offset" id="offset"/>
-                                    <input type="hidden" name="limit" id="limit"/>
+                                    <input type="hidden" name="limit" id="limit" value="<%= limit %>"/>
                                 </div>
                             </form>
                         </td>


### PR DESCRIPTION
Consultation request when clicking "Consultation Requests for this team" was giving a 500 error if the values weren't inputted. There were also issues with how the inputs would not save to their respective fields when the button was clicked. In main these were not issues so these fixes ensure that it works the same way.

This issue is listed in this ticket: https://github.com/cc-ar-emr/Open-O/issues/319

## Summary by Sourcery

Handle missing or empty consultation request form inputs to prevent server errors and retain user-entered values in the request view.

Bug Fixes:
- Prevent 500 errors by adding null checks and default values for missing consultation request parameters in the action class and JSP.
- Ensure form inputs (start/end dates, include completed checkbox, search date radio buttons, offset, and limit) retain their values after submission.

Enhancements:
- Refactor EctViewConsultationRequests2Action to use class-level properties with getters/setters and standardize String declarations.
- Add date formatting and value population in JSP using SimpleDateFormat to correctly display and prefill date fields.