### PR TITLE
Potential fix for code scanning alert no. 948: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/web/admin/FacilityManager2Action.java
+++ b/src/main/java/org/oscarehr/PMmodule/web/admin/FacilityManager2Action.java
@@ -249,7 +249,7 @@ public class FacilityManager2Action extends ActionSupport {
 
             return list();
         } catch (Exception e) {
-            addActionMessage(getText("duplicateKey", "The name " + facility.getName()));
+            addActionMessage(getText("duplicateKey", "The name " + sanitizeInput(facility.getName())));
             return FORWARD_EDIT;
         }
     }
@@ -287,5 +287,17 @@ public class FacilityManager2Action extends ActionSupport {
 
     public void setRegistrationIntakeForms(List<EForm> registrationIntakeForms) {
         this.registrationIntakeForms = registrationIntakeForms;
+    }
+    /**
+     * Sanitizes user-provided input to prevent OGNL injection or other vulnerabilities.
+     * @param input The user-provided input string.
+     * @return A sanitized version of the input string.
+     */
+    private String sanitizeInput(String input) {
+        if (input == null) {
+            return "";
+        }
+        // Replace potentially harmful characters or patterns
+        return input.replaceAll("[{}\\[\\]$]", "");
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/948](https://github.com/cc-ar-emr/Open-O/security/code-scanning/948)

To address the issue, the user-provided input (`facility.getName()`) should be validated or sanitized before being used in any context where it might be interpreted as an OGNL expression. A safe approach is to escape the input to neutralize any potentially harmful characters or patterns. Additionally, if the input is not intended to be evaluated as an OGNL expression, it should be explicitly treated as plain text.

The fix involves:
1. Adding a utility method to sanitize or escape user-provided input.
2. Applying this sanitization to `facility.getName()` before concatenating it with `"The name "` on line 252.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
