### PR TITLE
Fixed issue 352 - document saving notification display and remove provider issues

### DIFF
--- a/src/main/java/org/oscarehr/documentManager/actions/ManageDocument2Action.java
+++ b/src/main/java/org/oscarehr/documentManager/actions/ManageDocument2Action.java
@@ -119,6 +119,13 @@ public class ManageDocument2Action extends ActionSupport {
         ACTIONS.put("display", ctx -> { ctx.display(); return "display"; });
         ACTIONS.put("viewAnnotationAcknowledgementTickler", ctx -> { ctx.viewAnnotationAcknowledgementTickler(); return "viewAnnotationAcknowledgementTickler"; });
         ACTIONS.put("viewDocumentDescription", ctx -> { ctx.viewDocumentDescription(); return "viewDocumentDescription"; });
+        //  Enable calling the method to remove provider
+        ACTIONS.put("removeLinkFromDocument", new ActionHandler() {
+            public String handle(ManageDocument2Action action) {
+                action.removeLinkFromDocument();
+                return null;
+            }
+        });
     }
 
     // Called on default by struts.xml, finds the correct method to use by finding what the URL "method" param is equal to
@@ -265,7 +272,6 @@ public class ManageDocument2Action extends ActionSupport {
         if (!securityInfoManager.hasPrivilege(LoggedInInfo.getLoggedInInfoFromSession(request), "_edoc", "w", null)) {
             throw new SecurityException("missing required security object (_edoc)");
         }
-
 
         providerInboxRoutingDAO.removeLinkFromDocument(docType, Integer.parseInt(docId), providerNo);
         HashMap hm = new HashMap();

--- a/src/main/webapp/documentManager/showDocument.jsp
+++ b/src/main/webapp/documentManager/showDocument.jsp
@@ -458,6 +458,7 @@
                     <form id="forms_<%=docId%>" onsubmit="return updateDocument('forms_<%=docId%>');">
                         <input type="hidden" name="method" value="documentUpdateAjax"/>
                         <input type="hidden" name="documentId" value="<%=docId%>"/>
+                        <input type="hidden" name="providerNo" value="<%= providerNo%>"/>
                         <input type="hidden" name="curPage_<%=docId%>" id="curPage_<%=docId%>" value="1"/>
                         <input type="hidden" name="totalPage_<%=docId%>" id="totalPage_<%=docId%>"
                                value="<%=numOfPage%>"/>


### PR DESCRIPTION
Described in issue ticket #352

## Summary by Sourcery

Enable removing provider links from documents by adding a new Struts action and form field, and refactor the JavaScript document update flow to reliably show save notifications, disable autocomplete, and improve error handling.

New Features:
- Add ‘removeLinkFromDocument’ Struts action handler and include providerNo hidden field in the document form to support provider link removal

Bug Fixes:
- Fix document save notification display and autocomplete disabling by correcting element lookups and applying inline styles upon successful save

Enhancements:
- Refactor updateDocument AJAX callback to use vanilla DOM methods, wrap JSON parsing in try-catch, and add onFailure logging