### PR TITLE
Fixed the button style issues in message module

### DIFF
--- a/src/main/webapp/oscarMessenger/DisplayMessages.jsp
+++ b/src/main/webapp/oscarMessenger/DisplayMessages.jsp
@@ -299,7 +299,7 @@
                                             <tr>
                                                 <td class="messengerButtonsA">
                                                     <a href="${pageContext.request.contextPath}/oscarMessenger/CreateMessage.jsp"
-                                                               styleClass="messengerButtons">
+                                                               class="messengerButtons">
                                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.DisplayMessages.btnCompose"/>
                                                     </a>
                                                 </td>
@@ -311,7 +311,7 @@
                                             <tr>
                                                 <td class="messengerButtonsA">
                                                     <a href="${pageContext.request.contextPath}/oscarMessenger/DisplayMessages.jsp"
-                                                               styleClass="messengerButtons">
+                                                               class="messengerButtons">
                                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.DisplayMessages.btnRefresh"/>
                                                     </a>
                                                 </td>
@@ -323,7 +323,7 @@
                                             <tr>
                                                 <td class="messengerButtonsA">
                                                     <a href="${pageContext.request.contextPath}/oscarMessenger/DisplayMessages.jsp?boxType=1"
-                                                               styleClass="messengerButtons">
+                                                               class="messengerButtons">
                                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.DisplayMessages.btnSent"/><!--sentMessage--link-->
                                                     </a>
                                                 </td>
@@ -335,7 +335,7 @@
                                             <tr>
                                                 <td class="messengerButtonsA">
                                                     <a href="${pageContext.request.contextPath}/oscarMessenger/DisplayMessages.jsp?boxType=2"
-                                                               styleClass="messengerButtons">
+                                                               class="messengerButtons">
                                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.DisplayMessages.btnDeletedMessage"/><!--deletedMessage--link-->
                                                     </a>
                                                 </td>

--- a/src/main/webapp/oscarMessenger/SentMessage.jsp
+++ b/src/main/webapp/oscarMessenger/SentMessage.jsp
@@ -112,7 +112,7 @@
                                             <tr>
                                                 <td class="messengerButtonsA"><a
                                                         href="${pageContext.request.contextPath}/oscarMessenger/CreateMessage.jsp"
-                                                        styleClass="messengerButtons">
+                                                        class="messengerButtons">
                                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.SentMessage.btnCompose"/>
                                                 </a></td>
                                             </tr>
@@ -123,7 +123,7 @@
                                             <tr>
                                                 <td class="messengerButtonsA"><a
                                                         href="${pageContext.request.contextPath}/oscarMessenger/DisplayMessages.jsp"
-                                                        styleClass="messengerButtons">
+                                                        class="messengerButtons">
                                                     <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.SentMessagebtnBack"/>
                                                 </a></td>
                                             </tr>

--- a/src/main/webapp/oscarMessenger/ViewMessage.jsp
+++ b/src/main/webapp/oscarMessenger/ViewMessage.jsp
@@ -262,7 +262,7 @@
                                                     <tr>
                                                         <td class="messengerButtonsA"><a
                                                                 href="${pageContext.request.contextPath}/oscarMessenger/CreateMessage.jsp"
-                                                                styleClass="messengerButtons">
+                                                                class="messengerButtons">
                                                             <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.ViewMessage.btnCompose"/>
                                                         </a></td>
                                                     </tr>
@@ -287,7 +287,7 @@
                                                     <tr>
                                                         <td class="messengerButtonsA"><a
                                                                 href="${pageContext.request.contextPath}/oscarMessenger/DisplayMessages.jsp"
-                                                                styleClass="messengerButtons">
+                                                                class="messengerButtons">
                                                             <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.ViewMessage.btnInbox"/>
                                                         </a></td>
                                                     </tr>
@@ -301,7 +301,7 @@
                                                 <tr>
                                                     <td class="messengerButtonsA"><a
                                                             href="${pageContext.request.contextPath}/oscarMessenger/DisplayMessages.jsp?boxType=1"
-                                                            styleClass="messengerButtons">
+                                                            class="messengerButtons">
                                                         <fmt:setBundle basename="oscarResources"/><fmt:message key="oscarMessenger.ViewMessage.btnSent"/>
                                                     </a></td>
                                                 </tr>


### PR DESCRIPTION
Described in issue ticket #353

## Summary by Sourcery

Bug Fixes:
- Replace styleClass with class attribute on messenger buttons in DisplayMessages.jsp, ViewMessage.jsp, and SentMessage.jsp to restore correct styling.