### PR TITLE
fix: changes to existing consult don't persist

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
+++ b/src/main/java/oscar/oscarEncounter/oscarConsultationRequest/pageUtil/EctConsultationFormRequest2Action.java
@@ -291,7 +291,16 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                 }
 
                 ConsultationRequest consult = consultationRequestDao.find(new Integer(requestId));
-                Date date = DateUtils.parseDate(this.getReferalDate(), format);
+                Date date = null;
+
+                // By default, the referral date will not have a value on edit, so we need to make sure
+                // that the newly inputted date is parsed, or pulled from the previous date value
+                if (StringUtils.isNotBlank(this.getReferalDate())) {
+                    date = DateUtils.parseDate(this.getReferalDate(), format);
+                } else {
+                    date = consult.getReferralDate();
+                }
+
                 consult.setReferralDate(date);
                 consult.setServiceId(new Integer(this.getService()));
                 consult.setSignatureImg(signatureId);
@@ -382,8 +391,6 @@ public class EctConsultationFormRequest2Action extends ActionSupport {
                 }
 
                 // save any additional attachments added on the update
-
-
                 documentAttachmentManager.attachToConsult(loggedInInfo, DocumentType.DOC, attachedDocuments, providerNo, Integer.parseInt(requestId), Integer.parseInt(demographicNo));
                 documentAttachmentManager.attachToConsult(loggedInInfo, DocumentType.LAB, attachedLabs, providerNo, Integer.parseInt(requestId), Integer.parseInt(demographicNo));
                 documentAttachmentManager.attachToConsult(loggedInInfo, DocumentType.FORM, attachedForms, providerNo, Integer.parseInt(requestId), Integer.parseInt(demographicNo));


### PR DESCRIPTION
Changes to an existing consult now persist. The reason was that the date is default to no value if the paramater "id" is not null (this consultation already exists and is being edited). So I have a check to make sure that it either parses the new value or defaults back to the current db value if null.

I could change the date and consultation reason to populate when editing, but from my current understanding of this and main's code, I think this wasn't included on purpose. That could be possibly be wrong. I will create new changes if this is requested

## Summary by Sourcery

Bug Fixes:
- Preserve the existing referral date when editing a consult if no new date is provided