### PR TITLE
Fixed patient's history pages' errors, enabled displaying the history records

### DIFF
--- a/src/main/webapp/casemgmt/showHistory.jsp
+++ b/src/main/webapp/casemgmt/showHistory.jsp
@@ -62,7 +62,7 @@
                 </p>
             </div>
             <div style="color: #0000FF;">
-                <c:if test="${not empty current[idx] and current[idx] == false}">
+                <c:if test="${not empty current[idx.index] and current[idx.index] == false}">
                     <div style="color: #FF0000;">REMOVED</div>
                 </c:if>
                 <c:if test="${note.archived == true}">


### PR DESCRIPTION
Issue described in #399

## Summary by Sourcery

Bug Fixes:
- Change incorrect current[idx] reference to current[idx.index] in showHistory.jsp conditional to resolve errors and enable record display