### PR TITLE
fix: unable to filter encounter notes

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/service/impl/DefaultNoteService.java
+++ b/src/main/java/org/oscarehr/casemgmt/service/impl/DefaultNoteService.java
@@ -589,8 +589,10 @@ public class DefaultNoteService implements NoteService {
 
         if (issueId.contains("n")) {
             for (EChartNoteEntry e : notes) {
+                Integer id = safeToInt(e.getId());
+                if (id == null) continue;
                 List<CaseManagementIssue> issues = cmeIssueNotesDao
-                        .getNoteIssues((Integer.valueOf(e.getId().toString())));
+                        .getNoteIssues(id);
                 if (issues.size() == 0) {
                     filteredNotes.add(e);
                 }
@@ -615,6 +617,20 @@ public class DefaultNoteService implements NoteService {
         }
 
         return filteredNotes;
+    }
+
+    public Integer safeToInt(Object obj) {
+        if (obj instanceof Number) return ((Number) obj).intValue();
+        if (obj instanceof String[]) {
+            String[] arr = (String[]) obj;
+            if (arr.length > 0) obj = arr[0];
+            else return null;
+        }
+        try {
+            return Integer.valueOf(String.valueOf(obj));
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private CaseManagementNote findNote(Long id, List<CaseManagementNote> notes) {

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -513,9 +513,9 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         }
 
         session.setAttribute("note_sort", request.getParameter("note_sort"));
-        session.setAttribute("filter_roles", request.getParameter("filter_roles"));
-        session.setAttribute("filter_provider", request.getParameter("filter_providers"));
-        session.setAttribute("issues", request.getParameter("issues"));
+        session.setAttribute("filter_roles", request.getParameterValues("filter_roles"));
+        session.setAttribute("filter_provider", request.getParameterValues("filter_providers"));
+        session.setAttribute("issues", request.getParameterValues("issues"));
 
         return fwd;
     }

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -512,6 +512,11 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
             }
         }
 
+        session.setAttribute("note_sort", request.getParameter("note_sort"));
+        session.setAttribute("filter_roles", request.getParameter("filter_roles"));
+        session.setAttribute("filter_provider", request.getParameter("filter_providers"));
+        session.setAttribute("issues", request.getParameter("issues"));
+
         return fwd;
     }
 

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementView2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementView2Action.java
@@ -1867,10 +1867,10 @@ public class CaseManagementView2Action extends ActionSupport {
         criteria.setUserName((String) request.getSession().getAttribute("user"));
 
         // First, try to get the filter strings from the parameters
-        String note_sort_param = getFilterParams("note_sort");
-        String filter_roles_param = getFilterParams("filter_roles");
-        String filter_provider_param = getFilterParams("filter_provider");
-        String[] issues_param = getFilterParamValues("issues");
+        String note_sort_param = getSingleRequestValue("note_sort");
+        String[] filter_roles_param = getArrayRequestValue("filter_roles");
+        String[] filter_provider_param = getArrayRequestValue("filter_provider");
+        String[] issues_param = getArrayRequestValue("issues");
 
         // Ensure that both tries have set it at least once
         if (note_sort_param != null && !note_sort_param.isEmpty()) {
@@ -1917,7 +1917,7 @@ public class CaseManagementView2Action extends ActionSupport {
         return "ajaxDisplayNotes";
     }
 
-    private String getFilterParams(String paramName) {
+    private String getSingleRequestValue(String paramName) {
         // First, try to get the filter strings from the parameter
         String filterParam = request.getParameter(paramName);
         // If null, First, try to get the filter strings from the session, remove after setting variable
@@ -1928,7 +1928,7 @@ public class CaseManagementView2Action extends ActionSupport {
         return filterParam;
     }
 
-    private String[] getFilterParamValues(String paramName) {
+    private String[] getArrayRequestValue(String paramName) {
         // First, try to get the filter strings values from the parameter
         String[] filterParams = request.getParameterValues(paramName);
         if (filterParams == null) {

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementView2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementView2Action.java
@@ -1866,7 +1866,6 @@ public class CaseManagementView2Action extends ActionSupport {
         criteria.setUserRole((String) request.getSession().getAttribute("userrole"));
         criteria.setUserName((String) request.getSession().getAttribute("user"));
 
-        // First, try to get the filter strings from the parameters
         getParamOrSession("note_sort")
             .ifPresent(criteria::setNoteSort);
 
@@ -1874,8 +1873,6 @@ public class CaseManagementView2Action extends ActionSupport {
             criteria.getRoles().addAll(rs);
             se.setAttribute("CaseManagementViewAction_filter_roles", rs);
         });
-
-
         getParamsOrSession("filter_provider").ifPresent(rs -> {
             criteria.getProviders().addAll(rs);
             se.setAttribute("CaseManagementViewAction_filter_providers", rs);
@@ -1909,6 +1906,8 @@ public class CaseManagementView2Action extends ActionSupport {
         return "ajaxDisplayNotes";
     }
 
+    // Gets the parameters or attributes that are connected to the inputted name
+    // Works for string outputs
     private Optional<String> getParamOrSession(String name) {
         HttpSession session = request.getSession();
         String val = request.getParameter(name);
@@ -1919,6 +1918,8 @@ public class CaseManagementView2Action extends ActionSupport {
         return Optional.ofNullable(val).filter(s -> !s.isEmpty());
     }
 
+    // Gets the parameters or attributes that are connected to the inputted name
+    // Works for Array and List string outputs
     private Optional<List<String>> getParamsOrSession(String name) {
         HttpSession session = request.getSession();
         String[] vals = request.getParameterValues(name);

--- a/src/main/java/org/oscarehr/common/dao/CaseManagementIssueNotesDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/CaseManagementIssueNotesDaoImpl.java
@@ -62,15 +62,22 @@ public class CaseManagementIssueNotesDaoImpl implements CaseManagementIssueNotes
         if (issueId.length == 1 && issueId[0].equals(""))
             return null;
 
-        StringBuilder issueIdList = new StringBuilder();
-        for (String i : issueId) {
-            if (issueIdList.length() > 0)
-                issueIdList.append(",");
-            issueIdList.append(i);
+        // Build parameterized IN clause
+        StringBuilder placeholders = new StringBuilder();
+        for (int i = 0; i < issueId.length; i++) {
+            if (i > 0) {
+                placeholders.append(",");
+            }
+            placeholders.append("?").append(i + 1);
         }
-        String sql = "select note_id  from casemgmt_issue_notes where id in (" + issueIdList.toString() + ")";
+
+        String sql = "select note_id from casemgmt_issue_notes where id in (" + placeholders.toString() + ")";
 
         Query query = entityManager.createNativeQuery(sql);
+
+        for (int i = 0; i < issueId.length; i++) {
+            query.setParameter(i + 1, issueId[i]);
+        }
 
         @SuppressWarnings("unchecked")
         List<Integer> results = query.getResultList();

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -2181,14 +2181,23 @@ function updateCPPNote() {
 
         var caseMgtEntryfrm = document.forms["caseManagementEntryForm"];
         var caseMgtViewfrm = document.forms["caseManagementViewForm"];
+
+        // Temporarily remove one demographicNo field before serialization
+        var tempInput = caseMgtEntryfrm.demographicNo;
+        caseMgtEntryfrm.removeChild(tempInput);
+
         params += "&" + Form.serialize(caseMgtEntryfrm);
         params += "&" + Form.serialize(caseMgtViewfrm);
+
+        // Restore the field to the form after serialization
+        caseMgtEntryfrm.appendChild(tempInput);
 
         var objAjax = new Ajax.Request(
             url,
             {
                 method: 'post',
                 postBody: params,
+                contentType: 'application/x-www-form-urlencoded',
                 evalScripts: true,
                 onSuccess: function (request) {
                     $("notCPP").update(request.responseText);
@@ -2200,7 +2209,6 @@ function updateCPPNote() {
             }
         );
         return false;
-
     }
 
 // find index of month
@@ -2836,7 +2844,7 @@ function updateCPPNote() {
     function filterCheckBox(checkbox) {
         var checks = document.getElementsByName(checkbox.name);
 
-        if (checkbox.value == "a" && checkbox.checked) {
+        if (checkbox.value === "a" && checkbox.checked) {
 
             for (var idx = 0; idx < checks.length; ++idx) {
                 if (checks[idx] != checkbox)
@@ -2844,7 +2852,7 @@ function updateCPPNote() {
             }
         } else {
             for (var idx = 0; idx < checks.length; ++idx) {
-                if (checks[idx].value == "a") {
+                if (checks[idx].value === "a") {
                     if (checks[idx].checked)
                         checks[idx].checked = false;
 

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -2182,15 +2182,15 @@ function updateCPPNote() {
         var caseMgtEntryfrm = document.forms["caseManagementEntryForm"];
         var caseMgtViewfrm = document.forms["caseManagementViewForm"];
 
-        // Temporarily remove one demographicNo field before serialization
-        var tempInput = caseMgtEntryfrm.demographicNo;
-        caseMgtEntryfrm.removeChild(tempInput);
+        // Serialize caseMgtEntryfrm excluding demographicNo field, this is to avoid duplicate demographicNo
+        var clonedForm = caseMgtEntryfrm.cloneNode(true);
+        var demoField = clonedForm.demographicNo;
+        if (demoField) {
+            clonedForm.removeChild(demoField);
+        }
 
-        params += "&" + Form.serialize(caseMgtEntryfrm);
+        params += "&" + Form.serialize(clonedForm);
         params += "&" + Form.serialize(caseMgtViewfrm);
-
-        // Restore the field to the form after serialization
-        caseMgtEntryfrm.appendChild(tempInput);
 
         var objAjax = new Ajax.Request(
             url,

--- a/src/main/webapp/js/newCaseManagementView.js.jsp
+++ b/src/main/webapp/js/newCaseManagementView.js.jsp
@@ -2834,9 +2834,9 @@ function updateCPPNote() {
     function showFilter() {
 
         if (filterShows)
-            new Effect.BlindUp('filter');
+            new Effect.BlindUp('filter', { queue: 'end' });
         else
-            new Effect.BlindDown('filter');
+            new Effect.BlindDown('filter', { queue: 'end' });
 
         filterShows = !filterShows;
     }


### PR DESCRIPTION
Fixed issues with filter encounter notes buttons giving errors, fixed errors with "None" issue options always failing, Fixed sort params not being received at the correct method. Added comments and Util methods for safe conversion of int and request objects

## Summary by Sourcery

Fix filtering of encounter notes and ensure sort and filter parameters are handled correctly; introduce utility methods for robust parameter retrieval and type conversion; improve SQL parameterization and frontend form handling.

Bug Fixes:
- Restore proper filtering and sorting of encounter notes by correctly retrieving and persisting filter and sort parameters in server actions
- Prevent failures when filtering for "None" issues by adding safeToInt conversion for non-numeric IDs
- Resolve filter button errors by standardizing request and session parameter handling in viewNotesOpt

Enhancements:
- Add getSingleRequestValue and getArrayRequestValue helpers for unified request/session parameter extraction
- Parameterized SQL queries in CaseManagementIssueNotesDaoImpl to replace string concatenation for issue ID lists
- Refine frontend form logic by temporarily removing duplicate fields during serialization, specifying Ajax contentType, using strict equality, and controlling effect queueing in newCaseManagementView.js.jsp