### PR TITLE
Fixed EChart -> Encounter Notes -> Assign button's 500 error and its functionality, Enc Type selection error, and Edit button's 500 error

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -1445,7 +1445,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         String observationDate = this.getObservation_date();
         ResourceBundle props = ResourceBundle.getBundle("oscarResources", request.getLocale());
         if (observationDate != null && !observationDate.equals("")) {
-            SimpleDateFormat formatter = new SimpleDateFormat("dd-MMM-yyyy H:mm", request.getLocale());
+            SimpleDateFormat formatter = new SimpleDateFormat("dd-MMM-yyyy H:mm", Locale.ENGLISH);
             Date dateObserve = formatter.parse(observationDate);
             if (dateObserve.getTime() > now.getTime()) {
                 request.setAttribute("DateError", props.getString("oscarEncounter.futureDate.Msg"));

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -1840,7 +1840,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         note.setUpdate_date(now);
         if (note.getCreate_date() == null) note.setCreate_date(now);
 
-        note.setEncounter_type(request.getParameter("encType"));
+        note.setEncounter_type(request.getParameter("caseNote.encounter_type"));
 
         String hourOfEncounterTime = request.getParameter("hourOfEncounterTime");
         if (hourOfEncounterTime != null) {

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -1341,12 +1341,24 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         List<CaseManagementIssue> issuelist = new ArrayList<CaseManagementIssue>();
 
         CheckBoxBean[] checkedlist = sessionFrm.getIssueCheckList();
-
+        // this is for debugging, please keep it for future development
+        // System.out.println("Checkedlist from sessionFrm: " + Arrays.toString(checkedlist));
         // this gets attached to the CaseManagementNote object
         Set<CaseManagementIssue> issueset = new HashSet<CaseManagementIssue>();
         // wherever this is populated, it's not here...
         Set<CaseManagementNote> noteSet = new HashSet<CaseManagementNote>();
         String ongoing = new String();
+        if (checkedlist != null) {
+            for (CheckBoxBean cb : checkedlist) {
+                if ("on".equalsIgnoreCase(cb.getChecked())) {
+                    CaseManagementIssue issue = cb.getIssue();
+                    if (issue != null && issue.getId() != null) {
+                        issueset.add(issue);
+                    }
+                }
+            }
+        }
+        note.setIssues(issueset);
         Boolean useNewCaseMgmt = Boolean.valueOf((String) session.getAttribute("newCaseManagement"));
         if (useNewCaseMgmt) {
             ongoing = saveCheckedIssues_newCme(request, demo, note, issuelist, checkedlist, issueset, noteSet, ongoing);
@@ -3688,6 +3700,8 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
 
     protected CaseManagementIssue newIssueToCIssue(String demoNo, Issue iss, Integer programId) {
         CaseManagementIssue cIssue = new CaseManagementIssue();
+        demoNo = getDemographicNo(request);
+        request.setAttribute("demographicNo", demoNo);
         // cIssue.setActive(true);
         cIssue.setAcute(false);
         cIssue.setCertain(false);

--- a/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CaseManagementEntry2Action.java
@@ -1347,7 +1347,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         Set<CaseManagementIssue> issueset = new HashSet<CaseManagementIssue>();
         // wherever this is populated, it's not here...
         Set<CaseManagementNote> noteSet = new HashSet<CaseManagementNote>();
-        String ongoing = new String();
+        String ongoing = "";
         if (checkedlist != null) {
             for (CheckBoxBean cb : checkedlist) {
                 if ("on".equalsIgnoreCase(cb.getChecked())) {
@@ -3698,14 +3698,12 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
         return rt + "]\n";
     }
 
-    protected CaseManagementIssue newIssueToCIssue(String demoNo, Issue iss, Integer programId) {
+    protected CaseManagementIssue newIssueToCIssue(String demographicNo, Issue iss, Integer programId) {
         CaseManagementIssue cIssue = new CaseManagementIssue();
-        demoNo = getDemographicNo(request);
-        request.setAttribute("demographicNo", demoNo);
         // cIssue.setActive(true);
         cIssue.setAcute(false);
         cIssue.setCertain(false);
-        cIssue.setDemographic_no(Integer.valueOf(demoNo));
+        cIssue.setDemographic_no(Integer.valueOf(demographicNo));
 
         cIssue.setIssue_id(iss.getId().longValue());
 
@@ -3731,7 +3729,7 @@ public class CaseManagementEntry2Action extends ActionSupport implements Session
      * @param programId is optional, can be null for none.
      */
     protected CaseManagementIssue newIssueToCIssue(CaseManagementEntryFormBean cform, Issue iss, Integer programId) {
-        return newIssueToCIssue(this.getDemoNo(), iss, programId);
+        return newIssueToCIssue(this.getDemographicNo(), iss, programId);
     }
 
     protected Map<Long, CaseManagementIssue> convertIssueListToMap(List<CaseManagementIssue> issueList) {

--- a/src/main/java/org/oscarehr/casemgmt/web/CheckBoxBean.java
+++ b/src/main/java/org/oscarehr/casemgmt/web/CheckBoxBean.java
@@ -67,4 +67,14 @@ public class CheckBoxBean implements Serializable {
         this.issueDisplay = issueDisplay;
     }
 
+    /* this is for debugging in CaseManagementEntry2Action - noteSave(), please keep it for future development
+    @Override
+    public String toString() {
+        return "CheckBoxBean{" +
+                "checked='" + checked + '\'' +
+                ", isUsed=" + isUsed +
+                ", issueId=" + (issue != null ? issue.getId() : "null") +
+                ", issueDisplay=" + (issueDisplay != null ? issueDisplay.toString() : "null") +
+                '}';
+    }*/
 }

--- a/src/main/webapp/casemgmt/noteIssueList.jsp
+++ b/src/main/webapp/casemgmt/noteIssueList.jsp
@@ -213,42 +213,18 @@
     <span id="encType${noteIndex}">
         <c:choose>
             <c:when test="${empty ajaxsave}">
-                <select id="${encSelect}" class="encTypeCombo" name="encounter_type">
-                    <option value=""></option>
-                    <option value="face to face encounter with client">
-                        <fmt:setBundle basename="oscarResources"/>
-                        <fmt:message key="oscarEncounter.faceToFaceEnc.title"/>
-                    </option>
-                    <option value="telephone encounter with client">
-                        <fmt:setBundle basename="oscarResources"/>
-                        <fmt:message key="oscarEncounter.telephoneEnc.title"/>
-                    </option>
-                    <option value="email encounter with client">
-                        <fmt:setBundle basename="oscarResources"/>
-                        <fmt:message key="oscarEncounter.emailEnc.title"/>
-                    </option>
-                    <option value="encounter without client">
-                        <fmt:setBundle basename="oscarResources"/>
-                        <fmt:message key="oscarEncounter.noClientEnc.title"/>
-                    </option>
+                <select id="${encSelect}" class="encTypeCombo" name="caseNote.encounter_type">
+                    <option value="" ${empty caseManagementEntryForm.caseNote.encounter_type ? 'selected' : ''}></option>
+                    <option value="face to face encounter with client" ${caseManagementEntryForm.caseNote.encounter_type == 'face to face encounter with client' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.faceToFaceEnc.title"/></option>
+                    <option value="telephone encounter with client" ${caseManagementEntryForm.caseNote.encounter_type == 'telephone encounter with client' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.telephoneEnc.title"/></option>
+                    <option value="email encounter with client" ${caseManagementEntryForm.caseNote.encounter_type == 'email encounter with client' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.emailEnc.title"/></option>
+                    <option value="encounter without client" ${caseManagementEntryForm.caseNote.encounter_type == 'encounter without client' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.noClientEnc.title"/></option>
         
                     <c:if test="${loggedInInfo73557.currentFacility.enableGroupNotes}">
-                        <option value="group face to face encounter">
-                            <fmt:setBundle basename="oscarResources"/>
-                            <fmt:message key="oscarEncounter.groupFaceEnc.title"/>
-                        </option>
-                        <option value="group telephone encounter">
-                            <fmt:setBundle basename="oscarResources"/>
-                            <fmt:message key="oscarEncounter.groupTelephoneEnc.title"/>
-                        </option>
-                        <option value="group encounter with client">
-                            <fmt:setBundle basename="oscarResources"/>
-                            <fmt:message key="oscarEncounter.emailEnc.title"/>
-                        </option>
-                        <option value="group encounter without group">
-                            <fmt:setBundle basename="oscarResources"/>
-                            <fmt:message key="oscarEncounter.groupNoClientEnc.title"/>
-                        </option>
+                        <option value="group face to face encounter" ${caseManagementEntryForm.caseNote.encounter_type == 'group face to face encounter' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.groupFaceEnc.title"/></option>
+                        <option value="group telephone encounter" ${caseManagementEntryForm.caseNote.encounter_type == 'group telephone encounter' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.groupTelephoneEnc.title"/></option>
+                        <option value="group encounter with client" ${caseManagementEntryForm.caseNote.encounter_type == 'group encounter with client' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.emailEnc.title"/></option>
+                        <option value="group encounter without group" ${caseManagementEntryForm.caseNote.encounter_type == 'group encounter without group' ? 'selected' : ''}><fmt:setBundle basename="oscarResources"/><fmt:message key="oscarEncounter.groupNoClientEnc.title"/></option>
                     </c:if>
                 </select>
             </c:when>
@@ -256,7 +232,8 @@
                 "&quot;<c:out value="${caseManagementEntryForm.caseNote.encounter_type}"/>&quot;"
             </c:otherwise>
         </c:choose>        
-</span></div>
+    </span>
+</div>
 
 
 <c:set var="numIssues" value="${fn:length(caseManagementEntryForm.caseNote.issues)}"/>


### PR DESCRIPTION
Issue described in #402, #415, #417

## Summary by Sourcery

Fix the 500 error when assigning issues to encounter notes by properly checking and populating the issue set, ensure demographic number is retrieved and set for new issues, and add debugging hooks.

Bug Fixes:
- Prevent null pointer when processing the Issue checklist in noteSave by adding a null check and populating the issues set
- Attach the populated issues set to CaseManagementNote to restore Assign button functionality
- Retrieve and set the demographic number in newIssueToCIssue to avoid missing request attributes

Enhancements:
- Insert debug print statement in noteSave and commented toString in CheckBoxBean for future debugging