### PR TITLE
fix: unable to generate eform documents

### DIFF
--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wkhtmltopdf \
     locales iputils-ping gettext fontconfig libc6 libfreetype6 \
     libpng16-16 libssl-dev libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 libjpeg62 \
-    libxrender1 libfontconfig1 libxi6 xfonts-75dpi xfonts-base xvfb zlib1g maven mariadb-client \
+    libxrender1 libfontconfig1 libxi6 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
     nano openssh-client vim-tiny \
     python3 python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxrender1 libxi6 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
     nano openssh-client vim-tiny \
     python3 python3-pip \
+    wkhtmltopdf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Remove unnecessary default web apps in Tomcat

--- a/.devcontainer/development/Dockerfile
+++ b/.devcontainer/development/Dockerfile
@@ -25,12 +25,12 @@ WORKDIR /workspace
 # Install required packages and clean up apt lists
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dos2unix curl git wget apt-transport-https ca-certificates gnupg lsb-release \
+    wkhtmltopdf \
     locales iputils-ping gettext fontconfig libc6 libfreetype6 \
     libpng16-16 libssl-dev libstdc++6 libx11-6 libxcb1 libxext6 libxtst6 libjpeg62 \
-    libxrender1 libxi6 xfonts-75dpi xfonts-base zlib1g maven mariadb-client \
+    libxrender1 libfontconfig1 libxi6 xfonts-75dpi xfonts-base xvfb zlib1g maven mariadb-client \
     nano openssh-client vim-tiny \
     python3 python3-pip \
-    wkhtmltopdf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Remove unnecessary default web apps in Tomcat

--- a/.devcontainer/development/config/shared/volumes/oscar.properties
+++ b/.devcontainer/development/config/shared/volumes/oscar.properties
@@ -899,9 +899,9 @@ AdtA09Handler.CHECK_IN_EARLY_ALLOWANCE=4
 # and the executable is in the path of the running process.
 # This is used for converting html screens to pdf's.
 # This value should not be null.
-WKHTMLTOPDF_COMMAND=wkhtmltopdf-i386
-# Space-delimited arguments to be passed ot the WKHTMLTOPDF_COMMAND when invoking the converter
-WKHTMLTOPDF_ARGS=--print-media-type
+WKHTMLTOPDF_COMMAND=/usr/bin/wkhtmltopdf
+# Space-delimited arguments to be passed to the WKHTMLTOPDF_COMMAND when invoking the converter
+WKHTMLTOPDF_ARGS=--enable-local-file-access --minimum-font-size 10 --print-media-type --encoding utf-8 -T 10mm -L 8mm -R 8mm --disable-javascript
 # Port of the running OpenOSP emr server where HTML version of eforms for PDF generation can be downloaded from
 oscar_port=8080
 # This is the error correction level QR Codes will be rendered with. Do not change this value unless

--- a/src/main/java/org/oscarehr/documentManager/ConvertToEdoc.java
+++ b/src/main/java/org/oscarehr/documentManager/ConvertToEdoc.java
@@ -346,6 +346,9 @@ public final class ConvertToEdoc {
      * Converts HTML to PDF using the internal io.woo.htmltopdf library.
      * Only use this if you've bundled the required native .so file (e.g., libwkhtmltox.ubuntu.noble.amd64.so)
      * and WKHTMLTOPDF_COMMAND=internal is set.
+     * @param document the complete HTML string to convert to PDF
+     * @param os the {@link ByteArrayOutputStream} where the generated PDF content will be written
+     * @throws Exception if the external process fails or PDF conversion is unsuccessful
      */
     private static void convertWithInternal(String document, ByteArrayOutputStream os) throws Exception {
         // Settings for wkhtmltopdf behavior
@@ -371,9 +374,15 @@ public final class ConvertToEdoc {
     }
 
     /**
-     * Converts HTML to PDF using an external CLI tool, such as wkhtmltopdf or xvfb.
+     * Converts HTML to PDF using an external CLI tool, such as wkhtmltopdf.
      * Please set the WKHTMLTOPDF_COMMAND to your external CLI tool, 
      * and WKHTMLTOPDF_ARGS to your arguments that will be attached to the CLI tool call
+     * 
+     * @param command the full path to the external wkhtmltopdf executable (e.g., /usr/bin/wkhtmltopdf)
+     * @param args space-separated CLI arguments to pass to wkhtmltopdf (e.g., "--encoding utf-8")
+     * @param html the complete HTML string to convert to PDF
+     * @param os the {@link ByteArrayOutputStream} where the generated PDF content will be written
+     * @throws Exception if the external process fails or PDF conversion is unsuccessful
      */
     public static void convertWithExternal(String command, String args, String html, ByteArrayOutputStream os) throws Exception {
         // Prepare the list of command + args + "-" + "-" for stdin/stdout
@@ -389,9 +398,6 @@ public final class ConvertToEdoc {
         // Add stdin/stdout arguments
         commandParts.add("-");  // stdin
         commandParts.add("-");  // stdout
-
-        // Debug print final command array
-        System.out.println("🚀 Final command (ProcessBuilder args): " + commandParts);
 
         ProcessBuilder pb = new ProcessBuilder(commandParts);
         pb.redirectErrorStream(true); // merge stderr into stdout
@@ -478,16 +484,11 @@ public final class ConvertToEdoc {
             incomingDocumentString = "<!DOCTYPE html>" + incomingDocumentString;
         }
 
-        //TODO: COMING SOON.  EForms should be selectively sanitized against potential injection attacks and etc...
-//		Safelist safelist = Safelist.relaxed();
-//		safelist.addTags().addTags() etc...
-//		String sanitized = Jsoup.clean(documentString, safeList);
-
         Document document = Jsoup.parse(incomingDocumentString);
 
         document.outputSettings()
             .syntax(Document.OutputSettings.Syntax.xml)  // Enforce XML syntax
-            .escapeMode(Entities.EscapeMode.xhtml)        // XHTML entities
+            .escapeMode(Entities.EscapeMode.xhtml)
             .prettyPrint(false);
 
         // Ensure DOCTYPE is present

--- a/src/main/java/org/oscarehr/documentManager/EDocConverterInterface.java
+++ b/src/main/java/org/oscarehr/documentManager/EDocConverterInterface.java
@@ -1,0 +1,7 @@
+package org.oscarehr.documentManager;
+
+import java.io.OutputStream;
+
+public interface EDocConverterInterface {
+  void convert(String html, OutputStream os) throws Exception;
+}

--- a/src/main/java/org/oscarehr/documentManager/ExternalEDocConverter.java
+++ b/src/main/java/org/oscarehr/documentManager/ExternalEDocConverter.java
@@ -1,0 +1,43 @@
+package org.oscarehr.documentManager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.PumpStreamHandler;
+
+public class ExternalEDocConverter implements EDocConverterInterface {
+    private final CommandLine cmdLine;
+    private final DefaultExecutor executor = new DefaultExecutor();
+
+    public ExternalEDocConverter(String command, String args) {
+        cmdLine = new CommandLine(command);
+        cmdLine.addArguments(args, false);
+        cmdLine.addArgument("-", false); // stdin
+        cmdLine.addArgument("-", false); // stdout
+    }
+
+    /**
+     * Converts HTML to PDF using an external CLI tool, such as wkhtmltopdf.
+     * Please set the WKHTMLTOPDF_COMMAND to your external CLI tool, 
+     * and WKHTMLTOPDF_ARGS to your arguments that will be attached to the CLI tool call
+     * 
+     * @param html the complete HTML string to convert to PDF
+     * @param os the {@link ByteArrayOutputStream} where the generated PDF content will be written
+     * @throws Exception if the external process fails or PDF conversion is unsuccessful
+    */
+    @Override
+    public void convert(String document, OutputStream os) throws IOException {
+        ByteArrayInputStream stdin = new ByteArrayInputStream(document.getBytes(StandardCharsets.UTF_8));
+        PumpStreamHandler streams = new PumpStreamHandler(os, os, stdin);
+        executor.setStreamHandler(streams);
+        int exitCode = executor.execute(cmdLine);
+        if (exitCode != 0) {
+            throw new IOException("wkhtmltopdf failed with exit code " + exitCode);
+        }
+    }
+}

--- a/src/main/java/org/oscarehr/documentManager/InternalEDocConverter.java
+++ b/src/main/java/org/oscarehr/documentManager/InternalEDocConverter.java
@@ -1,0 +1,45 @@
+package org.oscarehr.documentManager;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+
+import io.woo.htmltopdf.HtmlToPdf;
+import io.woo.htmltopdf.HtmlToPdfObject;
+import io.woo.htmltopdf.PdfPageSize;
+
+public class InternalEDocConverter implements EDocConverterInterface {
+  /**
+   * Converts HTML to PDF using the internal io.woo.htmltopdf library.
+   * Only use this if you've bundled the required native .so file (e.g., libwkhtmltox.ubuntu.noble.amd64.so)
+   * and WKHTMLTOPDF_COMMAND=internal is set.
+   * @param document the complete HTML string to convert to PDF
+   * @param os the {@link ByteArrayOutputStream} where the generated PDF content will be written
+   * @throws Exception if the external process fails or PDF conversion is unsuccessful
+  */
+  @Override
+  public void convert(String document, OutputStream os) throws IOException {
+    Map<String,String> settings = Map.of(
+      "load.blockLocalFileAccess","false",
+      "web.enableIntelligentShrinking","true",
+      "web.minimumFontSize", "10",
+      "web.printMediaType", "true",
+      "web.defaultEncoding", "utf-8",
+      "T", "10mm",
+      "L", "8mm",
+      "R", "8mm",
+      "web.enableJavascript","false"
+    );
+    try(InputStream in = HtmlToPdf.create()
+        .object(HtmlToPdfObject.forHtml(document, settings))
+        .pageSize(PdfPageSize.Letter)
+        .convert())
+    {
+      IOUtils.copy(in, os);
+    }
+  }
+}

--- a/src/main/java/oscar/eform/EFormUtil.java
+++ b/src/main/java/oscar/eform/EFormUtil.java
@@ -27,6 +27,7 @@ package oscar.eform;
 
 import com.quatro.model.security.Secobjprivilege;
 import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -1631,8 +1632,14 @@ public class EFormUtil {
             if (currentErrors == null || currentErrors.isEmpty()) {
                 jsonArray = new JSONArray();
                 jsonArray.add(error);
-            } else {
-                jsonArray = JSONArray.fromObject(currentErrors);
+            } else {                    
+                try {
+                    jsonArray = JSONArray.fromObject(currentErrors);
+                } catch (JSONException e) {
+                    logger.warn("Malformed JSON in currentErrors, resetting: " + currentErrors, e);
+                    jsonArray = new JSONArray();
+                }
+
                 boolean addError = true;
                 for (Object jsonArrayObject : jsonArray) {
                     if (((String) jsonArrayObject).equalsIgnoreCase(error)) {

--- a/src/main/java/oscar/eform/actions/AddEForm2Action.java
+++ b/src/main/java/oscar/eform/actions/AddEForm2Action.java
@@ -440,15 +440,8 @@ public class AddEForm2Action extends ActionSupport {
             }
 		}
 
-        String fdid = eformDataManager.saveEformData(loggedInInfo, curForm) + "";
-        String path;
-
-        if (prev_fdid != null) {
-            path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
-        } else {
-            path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
-        }
-
+        String fdid = (String) request.getAttribute("fdid");
+        String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
 
 		String pdfBase64;
 		try {

--- a/src/main/java/oscar/eform/actions/AddEForm2Action.java
+++ b/src/main/java/oscar/eform/actions/AddEForm2Action.java
@@ -440,7 +440,15 @@ public class AddEForm2Action extends ActionSupport {
             }
 		}
 
-		String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
+        String fdid = eformDataManager.saveEformData(loggedInInfo, curForm) + "";
+        String path;
+
+        if (prev_fdid != null) {
+            path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
+        } else {
+            path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
+        }
+
 
 		String pdfBase64;
 		try {

--- a/src/main/java/oscar/eform/actions/AddEForm2Action.java
+++ b/src/main/java/oscar/eform/actions/AddEForm2Action.java
@@ -303,7 +303,7 @@ public class AddEForm2Action extends ActionSupport {
                 /*
                  * For now, this download code is added here and will be moved to the appropriate place after refactoring is done.
                  */
-                String path = "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
+                String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + fdid + "&parentAjaxId=eforms";
                 String fileName = generateFileName(loggedInInfo, Integer.parseInt(demographic_no));
                 String pdfBase64 = "";
                 try {
@@ -383,7 +383,7 @@ public class AddEForm2Action extends ActionSupport {
                 /*
                  * For now, this download code is added here and will be moved to the appropriate place after refactoring is done.
                  */
-                String path = "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
+                String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
                 String fileName = generateFileName(loggedInInfo, Integer.parseInt(demographic_no));
                 String pdfBase64 = "";
                 try {
@@ -440,7 +440,7 @@ public class AddEForm2Action extends ActionSupport {
             }
 		}
 
-		String path = "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
+		String path = request.getContextPath() + "/eform/efmshowform_data.jsp?fdid=" + prev_fdid + "&parentAjaxId=eforms";
 
 		String pdfBase64;
 		try {


### PR DESCRIPTION
Added fixes for:

1. EForm document error pop ups when clicking "Add to Documents"
2. 404 and 500 errors after clicking "Add to Documents"
3. Default and fallback code both failing with errors

## Summary by Sourcery

Fix issues preventing eform documents from generating and improve the HTML-to-PDF conversion process.

Bug Fixes:
- Handle malformed JSON in EFormUtil.logError by catching parse errors and resetting the error list
- Prefix JSP URLs with the request context path to prevent 404/500 errors when adding eforms to documents
- Enforce a DOCTYPE declaration and validate parsed HTML in ConvertToEdoc.getDocument to avoid invalid or empty document errors

Enhancements:
- Externalize PDF conversion settings via WKHTMLTOPDF_COMMAND and WKHTMLTOPDF_ARGS and choose between internal or external converters at runtime
- Refactor renderPDF to centrally manage conversion logic and add fallback to ITextRenderer on failures
- Add convertWithInternal, convertWithExternal, and splitArgs methods to support both bundled and system wkhtmltopdf libraries
- Configure Jsoup output settings to use XML syntax, XHTML escape mode, and disable pretty print for consistent HTML sanitization

Build:
- Install wkhtmltopdf and libfontconfig1 in the development Dockerfile
- Update default oscar.properties to reference the full wkhtmltopdf path and provide recommended CLI arguments