### PR TITLE
Added the filename validate rules to enhance security level of uploading files by Copilot's suggestion.

### DIFF
--- a/src/main/java/oscar/oscarLab/ca/all/upload/handlers/PATHL7Handler.java
+++ b/src/main/java/oscar/oscarLab/ca/all/upload/handlers/PATHL7Handler.java
@@ -100,7 +100,6 @@ public class PATHL7Handler implements MessageHandler {
         } else {
             return null;
         }
-
     }
 
 }

--- a/src/main/java/oscar/oscarLab/ca/all/upload/handlers/PATHL7Handler.java
+++ b/src/main/java/oscar/oscarLab/ca/all/upload/handlers/PATHL7Handler.java
@@ -64,6 +64,11 @@ public class PATHL7Handler implements MessageHandler {
 	}
 
     public String parse(LoggedInInfo loggedInInfo, String serviceName, String fileName, int fileId, String ipAddr) {
+        // Validate fileName to prevent path traversal
+        if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+            logger.error("Invalid file name: " + fileName);
+            return null;
+        }
         Document doc = null;
         try {
             DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();

--- a/src/main/java/oscar/oscarLab/ca/all/util/Utilities.java
+++ b/src/main/java/oscar/oscarLab/ca/all/util/Utilities.java
@@ -194,6 +194,13 @@ public class Utilities {
     public static String savePdfFile(InputStream stream, String filename) {
         String retVal = null;
         try {
+            // Validate filename to prevent path traversal and absolute paths
+            if (filename == null || filename.contains("..") || 
+            filename.contains("/") || filename.contains("\\") || 
+            filename.startsWith(".")) {
+                throw new IllegalArgumentException("Invalid filename: " + filename);
+            }
+
             OscarProperties props = OscarProperties.getInstance();
             //properties must exist
             String place = props.getProperty("DOCUMENT_DIR");
@@ -234,7 +241,11 @@ public class Utilities {
         } catch (IOException ioe) {
             logger.error("Error", ioe);
             return retVal;
+        } catch (IllegalArgumentException iae) {
+            logger.error("Invalid filename: " + filename, iae);
+            return null;
         }
+
         return retVal;
     }
 

--- a/src/main/java/oscar/oscarLab/ca/all/util/Utilities.java
+++ b/src/main/java/oscar/oscarLab/ca/all/util/Utilities.java
@@ -46,7 +46,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Date;
@@ -73,7 +72,6 @@ public class Utilities {
             String line = null;
             boolean firstPIDflag = false; //true if the first PID segment has been processed false otherwise
             boolean firstMSHflag = false; //true if the first MSH segment has been processed false otherwise
-            //String mshSeg = br.readLine();
 
             StringBuilder sb = new StringBuilder();
             String mshSeg = "";
@@ -111,7 +109,6 @@ public class Utilities {
 
         return (messages);
     }
-
 
     /**
      * @param stream
@@ -237,7 +234,6 @@ public class Utilities {
         } catch (FileNotFoundException fnfe) {
             logger.error("Error", fnfe);
             return retVal;
-
         } catch (IOException ioe) {
             logger.error("Error", ioe);
             return retVal;


### PR DESCRIPTION
Issue described in #422 and #424

## Summary by Sourcery

Validate uploaded file names to enhance security by preventing path traversal, absolute paths, and hidden files.

New Features:
- Add filename validation in savePdfFile to prevent path traversal, absolute paths, and hidden filenames
- Add filename validation in PATHL7Handler.parse to reject unsafe file names

Enhancements:
- Remove unused commented code and extra blank lines in Utilities