### PR TITLE
Potential fix for code scanning alert no. 1102: Partial path traversal vulnerability from remote

### DIFF
--- a/src/main/java/org/oscarehr/billing/CA/ON/web/MoveMOHFiles2Action.java
+++ b/src/main/java/org/oscarehr/billing/CA/ON/web/MoveMOHFiles2Action.java
@@ -6,7 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.struts2.ServletActionContext;
@@ -87,11 +88,12 @@ public class MoveMOHFiles2Action extends ActionSupport {
     private boolean validateFileLocation(File file) {
     boolean result = false;
     try {
-        String filePath = file.getCanonicalPath();
-        for(EDTFolder folder : EDTFolder.values()) {
-            String edtFolderPath = new File(folder.getPath()).getCanonicalPath();
+        Path filePath = file.toPath().toRealPath().normalize();
+        for (EDTFolder folder : EDTFolder.values()) {
+            Path edtFolderPath = Paths.get(folder.getPath()).toRealPath().normalize();
             if (filePath.startsWith(edtFolderPath)) {
                 result = true;
+                break;
             }
         }
     } catch (Exception e) {


### PR DESCRIPTION
Potential fix for [https://github.com/cc-ar-emr/Open-O/security/code-scanning/1102](https://github.com/cc-ar-emr/Open-O/security/code-scanning/1102)

To securely check that a user-supplied path is within an allowed directory, we should **ensure that the intended parent directory path is correctly slash-terminated** before using it for prefix checking, or, preferably, use `Path` objects and their `startsWith` method, which correctly handles directory boundaries in a platform-independent manner. 

In this code, the problematic check is in `validateFileLocation(File file)` where we loop over allowed folders, get their canonical path, and check if the user's canonical file path starts with that folder's canonical path. We should rewrite this check to use Java `Path` objects and normalization, and only accept the file if its normalized path is a child of the allowed parent directory.

Specifically, update:
- The check in `validateFileLocation` (lines 87-101), replacing the canonical path prefix comparison with a comparison between the normalized paths, using `Path.startsWith`.
- This may require an import for `java.nio.file.Path` and `java.nio.file.Paths`.
- No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Secure file location validation by replacing string-based canonical path prefix checks with normalized java.nio.file.Path startsWith comparisons to fix partial path traversal vulnerability

Bug Fixes:
- Prevent partial path traversal by validating file paths with normalized Path.startsWith instead of string prefix comparisons

Enhancements:
- Use java.nio.file.Path and Paths for canonicalization and normalization in validateFileLocation